### PR TITLE
Improve filter UI

### DIFF
--- a/src/BPMTool.css
+++ b/src/BPMTool.css
@@ -77,6 +77,8 @@
     gap: 1rem;
     max-width: 500px;
     width: 90%;
+    max-height: 90vh;
+    overflow-y: auto;
 }
 
 .api-key-modal-content h3 {
@@ -137,6 +139,12 @@
     border-radius: 0.375rem;
     cursor: pointer;
     margin-left: 0.5rem;
+    transition: background-color 0.2s;
+}
+
+.filter-button.active {
+    background-color: var(--accent-color);
+    color: var(--text-color);
 }
 
 .camera-modal {

--- a/src/BPMTool.jsx
+++ b/src/BPMTool.jsx
@@ -135,6 +135,15 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
     const [speedmod, setSpeedmod] = useState(1);
     const [showFilter, setShowFilter] = useState(false);
     const [songMeta, setSongMeta] = useState([]);
+    const filtersActive = Boolean(
+        filters.bpmMin !== '' ||
+        filters.bpmMax !== '' ||
+        filters.difficultyMin !== '' ||
+        filters.difficultyMax !== '' ||
+        filters.games.length > 0 ||
+        filters.artist !== '' ||
+        filters.multiBpm !== 'any'
+    );
 
     useEffect(() => {
         localStorage.setItem('isCollapsed', JSON.stringify(isCollapsed));
@@ -439,7 +448,9 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
                             />
                         </div>
                         {apiKey && <Camera onCapture={sendToGemini} isProcessing={isProcessing} />}
-                        <button className="filter-button" onClick={() => setShowFilter(true)}>Filters</button>
+                        <button className={`filter-button ${filtersActive ? 'active' : ''}`} onClick={() => setShowFilter(true)}>
+                            <i className="fa-solid fa-filter"></i>
+                        </button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- show filter status with button color and icon
- refine modal styling for mobile

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6876bff5cff883269faff7a22f457990