### PR TITLE
Improve PWA offline caching

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,7 +4,12 @@ import App from './App.jsx'
 import './index.css'
 import { registerSW } from 'virtual:pwa-register'
 
-registerSW({ immediate: true })
+const updateSW = registerSW({
+  immediate: true,
+  onNeedRefresh() {
+    updateSW(true)
+  },
+})
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,7 +4,7 @@ import App from './App.jsx'
 import './index.css'
 import { registerSW } from 'virtual:pwa-register'
 
-registerSW()
+registerSW({ immediate: true })
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/vite.config.js
+++ b/vite.config.js
@@ -64,6 +64,20 @@ export default defineConfig({
             }
           },
           {
+            urlPattern: /^https:\/\/cdnjs\.cloudflare\.com\/.*/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'cdnjs-cache',
+              expiration: {
+                maxEntries: 20,
+                maxAgeSeconds: 60 * 60 * 24 * 365 // 365 days
+              },
+              cacheableResponse: {
+                statuses: [0, 200]
+              }
+            }
+          },
+          {
             urlPattern: /\/sm-files\.json$/,
             handler: 'StaleWhileRevalidate',
             options: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,8 +28,11 @@ export default defineConfig({
         ]
       },
       workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg}', 'sm/**/*.{sm,ssc}'],
+        globPatterns: ['**/*'],
         navigateFallback: 'index.html',
+        cleanupOutdatedCaches: true,
+        clientsClaim: true,
+        skipWaiting: true,
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,

--- a/vite.config.js
+++ b/vite.config.js
@@ -29,6 +29,7 @@ export default defineConfig({
       },
       workbox: {
         globPatterns: ['**/*'],
+        maximumFileSizeToCacheInBytes: 100 * 1024 * 1024, // cache up to 100MB
         navigateFallback: 'index.html',
         cleanupOutdatedCaches: true,
         clientsClaim: true,


### PR DESCRIPTION
## Summary
- update vite PWA config to cache everything and auto update
- register the service worker immediately

## Testing
- `npm run lint` *(fails: no-unused-vars and other warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876d0b199a883269d528a6f9aa01df0