### PR TITLE
Add slack to multiple BPM filter

### DIFF
--- a/scripts/generate-song-meta.mjs
+++ b/scripts/generate-song-meta.mjs
@@ -42,7 +42,7 @@ async function main() {
           game,
           bpmMin,
           bpmMax,
-          hasMultipleBpms: uniqueBpms.length > 1,
+          hasMultipleBpms: bpmMax - bpmMin > 5,
           difficulties,
         });
       } catch (err) {

--- a/src/BPMTool.jsx
+++ b/src/BPMTool.jsx
@@ -346,8 +346,10 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
             if (!meta) return false;
             if (filters.games.length && !filters.games.includes(meta.game)) return false;
             if (filters.artist && !meta.artist.toLowerCase().includes(filters.artist.toLowerCase())) return false;
-            if (filters.multiBpm === 'single' && meta.hasMultipleBpms) return false;
-            if (filters.multiBpm === 'multiple' && !meta.hasMultipleBpms) return false;
+            const bpmDiff = meta.bpmMax - meta.bpmMin;
+            const isSingleBpm = bpmDiff <= 5;
+            if (filters.multiBpm === 'single' && !isSingleBpm) return false;
+            if (filters.multiBpm === 'multiple' && isSingleBpm) return false;
             if (filters.bpmMin !== '' && meta.bpmMax < Number(filters.bpmMin)) return false;
             if (filters.bpmMax !== '' && meta.bpmMin > Number(filters.bpmMax)) return false;
             if (filters.difficultyMin !== '' || filters.difficultyMax !== '') {


### PR DESCRIPTION
## Summary
- allow up to 5 BPM difference to still count as single BPM in BPMTool
- update metadata generation script accordingly

## Testing
- `npm run lint` *(fails: 28 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68775e9ef410832688e8bbd10308b767