### PR TITLE
Remove hover effects on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -236,9 +236,11 @@ body {
   border: 2px solid var(--accent-color);
   border-radius: 9999px;
 }
-.nav-link:hover {
-  color: var(--text-color);
-  background-color: var(--accent-color);
+@media (hover: hover) {
+  .nav-link:hover {
+    color: var(--text-color);
+    background-color: var(--accent-color);
+  }
 }
 
 
@@ -303,9 +305,11 @@ body {
   cursor: pointer;
   transition: all 0.2s;
 }
-.play-mode-toggle button:hover {
-	background-color: var(--card-hover-bg-color);
-	color: var(--text-color);
+@media (hover: hover) {
+  .play-mode-toggle button:hover {
+    background-color: var(--card-hover-bg-color);
+    color: var(--text-color);
+  }
 }
 
 .play-mode-toggle button.active {

--- a/src/BPMTool.css
+++ b/src/BPMTool.css
@@ -124,8 +124,10 @@
     transition: background-color 0.2s;
 }
 
-.api-key-modal-content button:hover {
-    background-color: var(--card-hover-bg-color-light);
+@media (hover: hover) {
+    .api-key-modal-content button:hover {
+        background-color: var(--card-hover-bg-color-light);
+    }
 }
 
 .game-checkboxes {
@@ -269,8 +271,10 @@
     flex-shrink: 0;
 }
 
-.collapse-button:hover {
-    background-color: var(--card-hover-bg-color-light);
+@media (hover: hover) {
+    .collapse-button:hover {
+        background-color: var(--card-hover-bg-color-light);
+    }
 }
 
 .chart-section.collapsed .chart-container {
@@ -362,24 +366,30 @@
     margin-top: 0;
 }
 
-.toggle-button:hover {
-    background-color: var(--card-hover-bg-color-light);
+@media (hover: hover) {
+    .toggle-button:hover {
+        background-color: var(--card-hover-bg-color-light);
+    }
 }
 
 .toggle-button.up {
     background-color: var(--button-up-color);
 }
 
-.toggle-button.up:hover {
-    background-color: var(--button-up-hover-color);
+@media (hover: hover) {
+    .toggle-button.up:hover {
+        background-color: var(--button-up-hover-color);
+    }
 }
 
 .toggle-button.down {
     background-color: var(--button-down-color);
 }
 
-.toggle-button.down:hover {
-    background-color: var(--button-down-hover-color);
+@media (hover: hover) {
+    .toggle-button.down:hover {
+        background-color: var(--button-down-hover-color);
+    }
 }
 
 .song-speed {
@@ -463,9 +473,11 @@
         justify-self: end;
         background-color: transparent;
     }
-    .collapse-button:hover {
-        background-color: transparent;
-        color: var(--text-muted-color);
+    @media (hover: hover) {
+        .collapse-button:hover {
+            background-color: transparent;
+            color: var(--text-muted-color);
+        }
     }
 
     .song-title-separator {
@@ -635,8 +647,10 @@
     transition: background-color 0.2s;
 }
 
-.smod-button:hover {
-    background-color: var(--card-hover-bg-color-light);
+@media (hover: hover) {
+    .smod-button:hover {
+        background-color: var(--card-hover-bg-color-light);
+    }
 }
 
 .smod-value {

--- a/src/Multiplier.css
+++ b/src/Multiplier.css
@@ -83,22 +83,28 @@
     margin: 1rem auto 0;
 }
 
-.toggle-button:hover {
-    background-color: var(--card-hover-bg-color-light);
+@media (hover: hover) {
+    .toggle-button:hover {
+        background-color: var(--card-hover-bg-color-light);
+    }
 }
 
 .toggle-button.up {
     background-color: var(--button-up-color);
 }
 
-.toggle-button.up:hover {
-    background-color: var(--button-up-hover-color);
+@media (hover: hover) {
+    .toggle-button.up:hover {
+        background-color: var(--button-up-hover-color);
+    }
 }
 
 .toggle-button.down {
     background-color: var(--button-down-color);
 }
 
-.toggle-button.down:hover {
-    background-color: var(--button-down-hover-color);
+@media (hover: hover) {
+    .toggle-button.down:hover {
+        background-color: var(--button-down-hover-color);
+    }
 }

--- a/src/Settings.css
+++ b/src/Settings.css
@@ -90,8 +90,10 @@
     transition: background-color 0.2s;
 }
 
-.settings-button:hover {
-    background-color: var(--accent-color-light);
+@media (hover: hover) {
+    .settings-button:hover {
+        background-color: var(--accent-color-light);
+    }
 }
 
 /* Mobile Layout */

--- a/src/Tabs.css
+++ b/src/Tabs.css
@@ -45,9 +45,11 @@
     
 }
 
-.settings-tab:hover {
-    background-color: var(--card-hover-bg-color);
-    color: var(--text-color);
+@media (hover: hover) {
+    .settings-tab:hover {
+        background-color: var(--card-hover-bg-color);
+        color: var(--text-color);
+    }
 }
 
 .settings-tab.active {
@@ -67,9 +69,11 @@
     
 }
 
-.tab:hover {
-    background-color: var(--card-hover-bg-color);
-    color: var(--text-color);
+@media (hover: hover) {
+    .tab:hover {
+        background-color: var(--card-hover-bg-color);
+        color: var(--text-color);
+    }
 }
 
 .tab.active {
@@ -92,8 +96,10 @@
     transition: all 0.2s ease-in-out;
 }
 
-.play-style-toggle-tab:hover {
-    background-color: var(--card-hover-bg-color);
+@media (hover: hover) {
+    .play-style-toggle-tab:hover {
+        background-color: var(--card-hover-bg-color);
+    }
 }
 
 @media (max-width: 640px) {

--- a/src/VegaPage.css
+++ b/src/VegaPage.css
@@ -34,8 +34,10 @@
     transition: background-color 0.2s;
 }
 
-.vega-button:hover {
-    background-color: var(--accent-color-light);
+@media (hover: hover) {
+    .vega-button:hover {
+        background-color: var(--accent-color-light);
+    }
 }
 
 

--- a/src/components/Breadcrumbs.module.css
+++ b/src/components/Breadcrumbs.module.css
@@ -24,6 +24,8 @@
     border-bottom: 2px solid transparent;
 }
 
-.link:hover {
-    border-bottom-color: var(--color-focal);
+@media (hover: hover) {
+    .link:hover {
+        border-bottom-color: var(--color-focal);
+    }
 }

--- a/src/components/FilterModal.module.css
+++ b/src/components/FilterModal.module.css
@@ -103,8 +103,10 @@
     transition: background-color 0.2s;
 }
 
-.checkboxLabel:hover {
-    background-color: var(--card-hover-bg-color);
+@media (hover: hover) {
+    .checkboxLabel:hover {
+        background-color: var(--card-hover-bg-color);
+    }
 }
 
 .checkboxLabel.selected {
@@ -112,8 +114,10 @@
     color: white;
 }
 
-.checkboxLabel.selected:hover {
-    background-color: var(--accent-color-light);
+@media (hover: hover) {
+    .checkboxLabel.selected:hover {
+        background-color: var(--accent-color-light);
+    }
 }
 
 .checkboxLabel input {
@@ -143,8 +147,10 @@
     color: white;
 }
 
-.applyButton:hover {
-    background-color: var(--accent-color-light);
+@media (hover: hover) {
+    .applyButton:hover {
+        background-color: var(--accent-color-light);
+    }
 }
 
 .resetButton {

--- a/src/components/SongCard.css
+++ b/src/components/SongCard.css
@@ -16,9 +16,11 @@
     color: inherit;
 }
 
-.song-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+@media (hover: hover) {
+    .song-card:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+    }
 }
 .song-title {
   font-weight: 700;

--- a/src/components/StepchartSection.module.css
+++ b/src/components/StepchartSection.module.css
@@ -45,8 +45,10 @@
     border-width: 0;
 }
 
-.bar:hover {
-    background-color: #c7d2fe; /* sm:bg-indigo-300 */
+@media (hover: hover) {
+    .bar:hover {
+        background-color: #c7d2fe; /* sm:bg-indigo-300 */
+    }
 }
 
 .bar:target, .targeted {
@@ -78,9 +80,11 @@
     border-bottom-left-radius: 0.5rem;
 }
 
-.bar:hover .selfLink svg,
-.selfLink:hover svg {
-    visibility: visible;
+@media (hover: hover) {
+    .bar:hover .selfLink svg,
+    .selfLink:hover svg {
+        visibility: visible;
+    }
 }
 
 .freeze {

--- a/src/components/ToggleBar.module.css
+++ b/src/components/ToggleBar.module.css
@@ -24,8 +24,10 @@
     color: var(--text-color);
 }
 
-.root input[type="radio"] + label:hover {
-    background-color: var(--card-hover-bg-color);
+@media (hover: hover) {
+    .root input[type="radio"] + label:hover {
+        background-color: var(--card-hover-bg-color);
+    }
 }
 
 .root input[type="radio"]:checked + label {


### PR DESCRIPTION
## Summary
- limit `.hover` styles to devices with a hover capable pointer

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68775dd110e4832683cc4a88f86a985e