### PR TITLE
Sort song select alphabetically

### DIFF
--- a/src/BPMTool.jsx
+++ b/src/BPMTool.jsx
@@ -361,12 +361,14 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
             return true;
         });
 
-        const options = filteredFiles.map(file => ({
-            value: file.path,
-            label: file.title,
-            title: file.title,
-            titleTranslit: file.titleTranslit
-        }));
+        const options = filteredFiles
+            .map(file => ({
+                value: file.path,
+                label: file.title,
+                title: file.title,
+                titleTranslit: file.titleTranslit,
+            }))
+            .sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }));
         setSongOptions(options);
     }, [selectedGame, smData, songMeta, filters]);
 


### PR DESCRIPTION
## Summary
- sort song options alphabetically so the select is easier to browse

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components, no-unused-vars, no-undef, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687762e0c6248326913aab76767cb72d