### PR TITLE
Fix filtering song selection

### DIFF
--- a/src/BPMTool.jsx
+++ b/src/BPMTool.jsx
@@ -373,6 +373,15 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
     }, [selectedGame, smData, songMeta, filters]);
 
     useEffect(() => {
+        if (!simfileData || songOptions.length === 0) return;
+        const currentTitle = simfileData.title.titleName;
+        const isValid = songOptions.some(opt => opt.title === currentTitle);
+        if (!isValid) {
+            onSongSelect(songOptions[0]);
+        }
+    }, [songOptions, simfileData]);
+
+    useEffect(() => {
         if (!simfileData || !currentChart) return;
 
         const mode = playStyle;


### PR DESCRIPTION
## Summary
- check song after applying filters and change song if needed

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68777822740883269f934b4bd3b8475e