### PR TITLE
Add custom list feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,9 +6,11 @@ import Tabs from './Tabs';
 import Settings from './Settings';
 import { SettingsProvider, SettingsContext } from './contexts/SettingsContext.jsx';
 import { FilterProvider } from './contexts/FilterContext.jsx';
+import { GroupsProvider } from './contexts/GroupsContext.jsx';
 import { findSongByTitle, loadSimfileData } from './utils/simfile-loader.js';
 import DanPage from './DanPage.jsx';
 import VegaPage from './VegaPage.jsx';
+import ListsPage from './ListsPage.jsx';
 import './App.css';
 import './Tabs.css';
 
@@ -117,8 +119,9 @@ function AppRoutes() {
           <Routes>
             <Route path="/dan" element={<DanPage activeDan={activeDan} setActiveDan={setActiveDan} setSelectedGame={setSelectedGame} />} />
             <Route path="/vega" element={<VegaPage activeVegaCourse={activeVegaCourse} setActiveVegaCourse={setActiveVegaCourse} setSelectedGame={setSelectedGame} />} />
-            <Route path="/multiplier" element={<Multiplier />} />
-            <Route path="/" element={<Navigate to="/bpm" replace />} />
+          <Route path="/multiplier" element={<Multiplier />} />
+          <Route path="/lists" element={<ListsPage />} />
+          <Route path="/" element={<Navigate to="/bpm" replace />} />
             <Route path="/bpm" element={<BPMTool smData={smData} simfileData={simfileData} currentChart={currentChart} setCurrentChart={handleChartSelect} onSongSelect={handleSongSelect} selectedGame={selectedGame} setSelectedGame={setSelectedGame} view={view} setView={setView} />} />
             <Route path="/settings" element={<Settings />} />
           </Routes>
@@ -135,9 +138,11 @@ function AppWrapper() {
   return (
     <SettingsProvider>
       <FilterProvider>
-        <Router>
-          <AppRoutes />
-        </Router>
+        <GroupsProvider>
+          <Router>
+            <AppRoutes />
+          </Router>
+        </GroupsProvider>
       </FilterProvider>
     </SettingsProvider>
   );

--- a/src/ListsPage.jsx
+++ b/src/ListsPage.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import SongCard from './components/SongCard.jsx';
+import { useGroups } from './contexts/GroupsContext.jsx';
+import './App.css';
+import './VegaPage.css';
+
+const GroupSection = ({ group, removeChart }) => (
+  <section className="dan-section">
+    <h2 className="dan-header">{group.name}</h2>
+    <div className="song-grid">
+      {group.charts.map((chart, idx) => (
+        <SongCard key={idx} song={chart} onRemove={() => removeChart(group.name, chart)} />
+      ))}
+      {group.charts.length === 0 && (
+        <p style={{ padding: '1rem', color: 'var(--text-muted-color)' }}>No charts in this list.</p>
+      )}
+    </div>
+  </section>
+);
+
+const ListsPage = () => {
+  const { groups, createGroup, removeChartFromGroup } = useGroups();
+  const [newName, setNewName] = useState('');
+
+  const handleCreate = () => {
+    const name = newName.trim();
+    if (name) {
+      createGroup(name);
+      setNewName('');
+    }
+  };
+
+  return (
+    <div className="app-container">
+      <main>
+        <div className="filter-bar">
+          <div className="filter-group">
+            <input
+              className="dan-select"
+              value={newName}
+              onChange={e => setNewName(e.target.value)}
+              placeholder="New list name"
+            />
+            <button className="vega-button" onClick={handleCreate}>Create</button>
+          </div>
+        </div>
+        {groups.map(g => (
+          <GroupSection key={g.name} group={g} removeChart={removeChartFromGroup} />
+        ))}
+      </main>
+    </div>
+  );
+};
+
+export default ListsPage;

--- a/src/Tabs.jsx
+++ b/src/Tabs.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCog, faTrophy, faCalculator, faArrowsUpDownLeftRight } from '@fortawesome/free-solid-svg-icons';
+import { faCog, faTrophy, faCalculator, faArrowsUpDownLeftRight, faList } from '@fortawesome/free-solid-svg-icons';
 import { SettingsContext } from './contexts/SettingsContext.jsx';
 import './Tabs.css';
 
@@ -34,6 +34,9 @@ const Tabs = () => {
                     </NavLink>
                     <NavLink to={`/multiplier${location.hash}`} className={({ isActive }) => (isActive ? 'tab active' : 'tab')}>
                         <FontAwesomeIcon icon={faCalculator} />
+                    </NavLink>
+                    <NavLink to={`/lists${location.hash}`} className={({ isActive }) => (isActive ? 'tab active' : 'tab')}>
+                        <FontAwesomeIcon icon={faList} />
                     </NavLink>
                 </div>
                 <div className="play-style-toggle-tab" onClick={() => setPlayStyle(s => s === 'single' ? 'double' : 'single')}>

--- a/src/components/SongCard.css
+++ b/src/components/SongCard.css
@@ -12,6 +12,7 @@
 }
 
 .song-card-link {
+    position: relative;
     text-decoration: none;
     color: inherit;
 }
@@ -97,4 +98,20 @@
   .song-card {
     min-height: 0px;
   }
+}
+
+.song-card-action {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background-color: var(--button-bg);
+  color: var(--button-icon);
+  border: none;
+  border-radius: 0.25rem;
+  padding: 0.25rem;
+  cursor: pointer;
+}
+.song-card-action.remove {
+  background-color: var(--button-down-color);
+  color: white;
 }

--- a/src/components/SongCard.jsx
+++ b/src/components/SongCard.jsx
@@ -1,6 +1,9 @@
 import React, { useMemo, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SettingsContext } from '../contexts/SettingsContext.jsx';
+import { useGroups } from '../contexts/GroupsContext.jsx';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus, faTimes } from '@fortawesome/free-solid-svg-icons';
 import './SongCard.css';
 
 const difficultyDisplayMap = {
@@ -27,8 +30,9 @@ const getBpmRange = (bpm) => {
   return { min: Math.min(...parts), max: Math.max(...parts) };
 };
 
-const SongCard = ({ song, setSelectedGame, resetFilters }) => {
+const SongCard = ({ song, setSelectedGame, resetFilters, onRemove }) => {
   const { targetBPM, multipliers } = useContext(SettingsContext);
+  const { groups, addChartToGroup, createGroup } = useGroups();
   const navigate = useNavigate();
 
   const calculation = useMemo(() => {
@@ -72,12 +76,31 @@ const SongCard = ({ song, setSelectedGame, resetFilters }) => {
     );
   }
 
+  const handleAdd = (e) => {
+    e.stopPropagation();
+    let name = prompt(`Add to which list?\nAvailable: ${groups.map(g => g.name).join(', ')}`);
+    if (!name) return;
+    if (!groups.some(g => g.name === name)) {
+      createGroup(name);
+    }
+    addChartToGroup(name, song);
+  };
+
   return (
     <div className="song-card-link" onClick={() => {
       if (resetFilters) resetFilters();
       navigate(`/bpm?difficulty=${song.difficulty}&mode=${song.mode}#${encodeURIComponent(song.title)}`);
     }}>
       <div className="song-card">
+        {onRemove ? (
+          <button className="song-card-action" onClick={(e) => { e.stopPropagation(); onRemove(); }}>
+            <FontAwesomeIcon icon={faTimes} />
+          </button>
+        ) : (
+          <button className="song-card-action" onClick={handleAdd}>
+            <FontAwesomeIcon icon={faPlus} />
+          </button>
+        )}
         <div className="song-card-header">
           <h3 className="song-title">{song.title}</h3>
           {song.game && <div className="game-chip">{song.game}</div>}

--- a/src/contexts/GroupsContext.jsx
+++ b/src/contexts/GroupsContext.jsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+const defaultGroups = [];
+
+export const GroupsContext = createContext();
+
+export const GroupsProvider = ({ children }) => {
+  const [groups, setGroups] = useState(() => {
+    const saved = localStorage.getItem('groups');
+    return saved ? JSON.parse(saved) : defaultGroups;
+  });
+
+  useEffect(() => {
+    localStorage.setItem('groups', JSON.stringify(groups));
+  }, [groups]);
+
+  const createGroup = (name) => {
+    if (!name || groups.some(g => g.name === name)) return;
+    setGroups(prev => [...prev, { name, charts: [] }]);
+  };
+
+  const deleteGroup = (name) => {
+    setGroups(prev => prev.filter(g => g.name !== name));
+  };
+
+  const addChartToGroup = (name, chart) => {
+    setGroups(prev => prev.map(g => g.name === name ? {
+      ...g,
+      charts: g.charts.some(c => c.title === chart.title && c.mode === chart.mode && c.difficulty === chart.difficulty) ? g.charts : [...g.charts, chart]
+    } : g));
+  };
+
+  const removeChartFromGroup = (name, chart) => {
+    setGroups(prev => prev.map(g => g.name === name ? {
+      ...g,
+      charts: g.charts.filter(c => !(c.title === chart.title && c.mode === chart.mode && c.difficulty === chart.difficulty))
+    } : g));
+  };
+
+  return (
+    <GroupsContext.Provider value={{ groups, createGroup, deleteGroup, addChartToGroup, removeChartFromGroup }}>
+      {children}
+    </GroupsContext.Provider>
+  );
+};
+
+export const useGroups = () => useContext(GroupsContext);


### PR DESCRIPTION
## Summary
- create GroupsContext to store user lists in localStorage
- add ListsPage for viewing and managing lists
- add new list tab in navigation
- allow adding/removing charts from lists using SongCard actions

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877938a14888326ae4f11dac228225c