### PR TITLE
Fix filter active state

### DIFF
--- a/src/BPMTool.jsx
+++ b/src/BPMTool.jsx
@@ -198,6 +198,7 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
         filters.lengthMin !== '' ||
         filters.lengthMax !== '' ||
         filters.games.length > 0 ||
+        (filters.difficultyNames && filters.difficultyNames.length > 0) ||
         filters.artist !== '' ||
         (filters.title && filters.title !== '') ||
         filters.multiBpm !== 'any'


### PR DESCRIPTION
## Summary
- mark filtersActive true when difficulty names are set

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877b7cb46908326acec2df8ae1c6753