### PR TITLE
Toggle play style when opening charts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ import './App.css';
 import './Tabs.css';
 
 function AppRoutes() {
-  const { theme, showLists } = useContext(SettingsContext);
+  const { theme, showLists, setPlayStyle } = useContext(SettingsContext);
   const [smData, setSmData] = useState({ games: [], files: [] });
   const [simfileData, setSimfileData] = useState(null);
   const [currentChart, setCurrentChart] = useState(null);
@@ -49,12 +49,19 @@ function AppRoutes() {
       const difficulty = queryParams.get('difficulty');
       const mode = queryParams.get('mode');
 
+      if (mode === 'single' || mode === 'double') {
+        setPlayStyle(mode);
+      }
+
       if (simfileData && simfileData.title.titleName.toLowerCase() === songTitle.toLowerCase()) {
         // If song is the same, check if we need to update the chart
         if (currentChart && difficulty && mode && (currentChart.difficulty.toLowerCase() !== difficulty.toLowerCase() || currentChart.mode.toLowerCase() !== mode.toLowerCase())) {
             const chartToSelect = simfileData.availableTypes.find(c => c.difficulty.toLowerCase() === difficulty.toLowerCase() && c.mode.toLowerCase() === mode.toLowerCase());
             if (chartToSelect) {
                 setCurrentChart(chartToSelect);
+                if (chartToSelect.mode) {
+                  setPlayStyle(chartToSelect.mode);
+                }
             }
         }
         return;
@@ -82,6 +89,9 @@ function AppRoutes() {
             }
           }
           setCurrentChart(chartToSelect);
+          if (chartToSelect && chartToSelect.mode) {
+            setPlayStyle(chartToSelect.mode);
+          }
         }
       }
     };
@@ -101,6 +111,9 @@ function AppRoutes() {
 
   const handleChartSelect = (chart) => {
     setCurrentChart(chart);
+    if (chart && chart.mode) {
+      setPlayStyle(chart.mode);
+    }
     const queryParams = new URLSearchParams(location.search);
     queryParams.set('difficulty', chart.difficulty);
     queryParams.set('mode', chart.mode);

--- a/src/components/SongCard.jsx
+++ b/src/components/SongCard.jsx
@@ -30,7 +30,7 @@ const getBpmRange = (bpm) => {
 };
 
 const SongCard = ({ song, setSelectedGame, resetFilters, onRemove }) => {
-  const { targetBPM, multipliers } = useContext(SettingsContext);
+  const { targetBPM, multipliers, setPlayStyle } = useContext(SettingsContext);
   const navigate = useNavigate();
 
   const calculation = useMemo(() => {
@@ -77,6 +77,7 @@ const SongCard = ({ song, setSelectedGame, resetFilters, onRemove }) => {
   return (
     <div className="song-card-link" onClick={() => {
       if (resetFilters) resetFilters();
+      if (setPlayStyle) setPlayStyle(song.mode);
       navigate(`/bpm?difficulty=${song.difficulty}&mode=${song.mode}#${encodeURIComponent(song.title)}`);
     }}>
       <div className="song-card">


### PR DESCRIPTION
## Summary
- switch the play style when selecting a chart
- update URL loading logic to sync play style from query params

## Testing
- `npm run lint` *(fails: Fast refresh and unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877ceb35c8c8326ba7ab0d11037c6a8