### PR TITLE
Add list selection dropdown and modal

### DIFF
--- a/src/ListsPage.css
+++ b/src/ListsPage.css
@@ -11,10 +11,25 @@
   min-width: 100px;
 }
 
-.list-page-filter-group > .vega-button {
+.list-page-filter-group > .filter-button {
   border: none;
   cursor: pointer;
   flex-shrink: 0;
+}
+
+.filter-button {
+  background-color: var(--card-bg-color);
+  border: 0px solid var(--border-color);
+  color: var(--text-color);
+  border-radius: 0.375rem;
+  cursor: pointer;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  transition: background-color 0.2s;
 }
 
 .dan-header {

--- a/src/ListsPage.jsx
+++ b/src/ListsPage.jsx
@@ -3,7 +3,8 @@ import SongCard from './components/SongCard.jsx';
 import { useGroups } from './contexts/GroupsContext.jsx';
 import { useFilters } from './contexts/FilterContext.jsx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTrash, faPalette } from '@fortawesome/free-solid-svg-icons';
+import { faTrash, faPalette, faPlus } from '@fortawesome/free-solid-svg-icons';
+import CreateListModal from './components/CreateListModal.jsx';
 import './App.css';
 import './VegaPage.css';
 import './ListsPage.css';
@@ -82,33 +83,57 @@ const GroupSection = ({ group, removeChart, deleteGroup, updateColor, updateName
 };
 
 const ListsPage = () => {
-  const { groups, createGroup, removeChartFromGroup, deleteGroup, updateGroupColor, updateGroupName } = useGroups();
+  const {
+    groups,
+    createGroup,
+    removeChartFromGroup,
+    deleteGroup,
+    updateGroupColor,
+    updateGroupName,
+    activeGroup,
+    setActiveGroup,
+  } = useGroups();
   const { resetFilters } = useFilters();
-  const [newName, setNewName] = useState('');
+  const [showCreateModal, setShowCreateModal] = useState(false);
 
-  const handleCreate = () => {
-    const name = newName.trim();
-    if (name) {
-      createGroup(name);
-      setNewName('');
+  const handleCreate = (name) => {
+    if (name.trim()) {
+      createGroup(name.trim());
     }
   };
+
+  const groupsToShow =
+    activeGroup === 'All' ? groups : groups.filter(g => g.name === activeGroup);
 
   return (
     <div className="app-container">
       <main>
         <div className="filter-bar">
           <div className="filter-group list-page-filter-group">
-            <input
-              className="dan-select"
-              value={newName}
-              onChange={e => setNewName(e.target.value)}
-              placeholder="New list name"
-            />
-            <button className="vega-button" onClick={handleCreate}>Create</button>
+            <div className="dan-select-wrapper">
+              <select
+                value={activeGroup}
+                onChange={e => setActiveGroup(e.target.value)}
+                className="dan-select"
+              >
+                <option value="All">All Lists</option>
+                {groups.map(g => (
+                  <option key={g.name} value={g.name}>
+                    {g.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button
+              className="filter-button"
+              onClick={() => setShowCreateModal(true)}
+              title="Add list"
+            >
+              <FontAwesomeIcon icon={faPlus} />
+            </button>
           </div>
         </div>
-        {groups.map(g => (
+        {groupsToShow.map(g => (
           <GroupSection
             key={g.name}
             group={g}
@@ -119,6 +144,11 @@ const ListsPage = () => {
             resetFilters={resetFilters}
           />
         ))}
+        <CreateListModal
+          isOpen={showCreateModal}
+          onClose={() => setShowCreateModal(false)}
+          onCreate={handleCreate}
+        />
       </main>
     </div>
   );

--- a/src/components/CreateListModal.jsx
+++ b/src/components/CreateListModal.jsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect } from 'react';
+import styles from './AddToListModal.module.css';
+
+const CreateListModal = ({ isOpen, onClose, onCreate }) => {
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setName('');
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleCreate = () => {
+    const trimmed = name.trim();
+    if (trimmed) {
+      onCreate(trimmed);
+      onClose();
+    }
+  };
+
+  return (
+    <div className={styles.modalBackdrop} onClick={onClose}>
+      <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
+        <h3 className={styles.modalHeader}>Create New List</h3>
+        <div className={styles.modalBody}>
+          <div className={styles.formGroup}>
+            <label>List Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className={styles.input}
+              placeholder="List name"
+            />
+          </div>
+        </div>
+        <div className={styles.buttonGroup}>
+          <button onClick={onClose} className={`${styles.button} ${styles.cancelButton}`}>Cancel</button>
+          <button onClick={handleCreate} className={`${styles.button} ${styles.applyButton}`}>Create</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CreateListModal;

--- a/src/contexts/GroupsContext.jsx
+++ b/src/contexts/GroupsContext.jsx
@@ -10,10 +10,23 @@ export const GroupsProvider = ({ children }) => {
     const saved = localStorage.getItem('groups');
     return saved ? JSON.parse(saved) : defaultGroups;
   });
+  const [activeGroup, setActiveGroup] = useState(() =>
+    localStorage.getItem('activeGroup') || 'All'
+  );
 
   useEffect(() => {
     localStorage.setItem('groups', JSON.stringify(groups));
   }, [groups]);
+
+  useEffect(() => {
+    localStorage.setItem('activeGroup', activeGroup);
+  }, [activeGroup]);
+
+  useEffect(() => {
+    if (activeGroup !== 'All' && !groups.some(g => g.name === activeGroup)) {
+      setActiveGroup('All');
+    }
+  }, [groups, activeGroup]);
 
   const createGroup = (name) => {
     if (groups.length >= MAX_GROUPS) {
@@ -71,7 +84,18 @@ export const GroupsProvider = ({ children }) => {
   };
 
   return (
-    <GroupsContext.Provider value={{ groups, createGroup, deleteGroup, addChartToGroup, removeChartFromGroup, updateGroupColor, addChartsToGroup, updateGroupName }}>
+    <GroupsContext.Provider value={{
+      groups,
+      createGroup,
+      deleteGroup,
+      addChartToGroup,
+      removeChartFromGroup,
+      updateGroupColor,
+      addChartsToGroup,
+      updateGroupName,
+      activeGroup,
+      setActiveGroup,
+    }}>
       {children}
     </GroupsContext.Provider>
   );


### PR DESCRIPTION
## Summary
- allow active list selection with state saved to localStorage
- show a dropdown of lists and a plus button on Lists page
- open a modal for creating a new list

## Testing
- `npm run lint` *(fails: useMemo defined but never used, useRef defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6877df89790883269562eaeb39c2d3c0