### PR TITLE
Highlight active filters

### DIFF
--- a/src/components/FilterModal.jsx
+++ b/src/components/FilterModal.jsx
@@ -74,27 +74,36 @@ const FilterModal = ({ isOpen, onClose, games, showLists, onCreateList }) => {
 
   if (!isOpen) return null;
 
+  const bpmActive = localFilters.bpmMin !== '' || localFilters.bpmMax !== '';
+  const diffRangeActive = localFilters.difficultyMin !== '' || localFilters.difficultyMax !== '';
+  const diffNamesActive = localFilters.difficultyNames.length > 0;
+  const lengthActive = localFilters.lengthMin !== '' || localFilters.lengthMax !== '';
+  const artistActive = localFilters.artist !== '';
+  const titleActive = localFilters.title !== '';
+  const gamesActive = localFilters.games.length > 0;
+  const multiBpmActive = localFilters.multiBpm !== 'any';
+
   return (
     <div className={styles.modalBackdrop} onClick={onClose}>
       <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
         <h3 className={styles.modalHeader}>Song Filters</h3>
         <div className={styles.modalBody}>
           <div className={styles.column}>
-            <div className={styles.formGroup}>
+            <div className={`${styles.formGroup} ${bpmActive ? styles.activeGroup : ''}`}>
               <label>BPM Range (1-1100)</label>
               <div className={styles.inputGroup}>
                 <input type="number" min="1" max="1100" placeholder="Min" value={localFilters.bpmMin} onChange={e => setLocalFilters(f => ({ ...f, bpmMin: e.target.value }))} onBlur={e => handleRangeBlur('bpmMin', e.target.value, 1, 1100)} className={styles.input} />
                 <input type="number" min="1" max="1100" placeholder="Max" value={localFilters.bpmMax} onChange={e => setLocalFilters(f => ({ ...f, bpmMax: e.target.value }))} onBlur={e => handleRangeBlur('bpmMax', e.target.value, 1, 1100)} className={styles.input} />
               </div>
             </div>
-            <div className={styles.formGroup}>
+            <div className={`${styles.formGroup} ${diffRangeActive ? styles.activeGroup : ''}`}>
               <label>Difficulty Range (1-19)</label>
               <div className={styles.inputGroup}>
                 <input type="number" min="1" max="19" placeholder="Min" value={localFilters.difficultyMin} onChange={e => setLocalFilters(f => ({ ...f, difficultyMin: e.target.value }))} onBlur={e => handleRangeBlur('difficultyMin', e.target.value, 1, 19)} className={styles.input} />
                 <input type="number" min="1" max="19" placeholder="Max" value={localFilters.difficultyMax} onChange={e => setLocalFilters(f => ({ ...f, difficultyMax: e.target.value }))} onBlur={e => handleRangeBlur('difficultyMax', e.target.value, 1, 19)} className={styles.input} />
               </div>
             </div>
-            <div className={styles.formGroup}>
+            <div className={`${styles.formGroup} ${diffNamesActive ? styles.activeGroup : ''}`}>
               <label>Difficulty Names</label>
               <div className={styles.gameCheckboxes}>
                 {difficultyNames.map(name => {
@@ -110,7 +119,7 @@ const FilterModal = ({ isOpen, onClose, games, showLists, onCreateList }) => {
                 })}
               </div>
             </div>
-            <div className={styles.formGroup}>
+            <div className={`${styles.formGroup} ${lengthActive ? styles.activeGroup : ''}`}>
               <label>Length (seconds)</label>
               <div className={styles.inputGroup}>
                 <input type="number" min="1" max="600" placeholder="Min" value={localFilters.lengthMin} onChange={e => setLocalFilters(f => ({ ...f, lengthMin: e.target.value }))} onBlur={e => handleRangeBlur('lengthMin', e.target.value, 1, 600)} className={styles.input} />
@@ -119,15 +128,15 @@ const FilterModal = ({ isOpen, onClose, games, showLists, onCreateList }) => {
             </div>
           </div>
           <div className={styles.column}>
-            <div className={styles.formGroup}>
+            <div className={`${styles.formGroup} ${artistActive ? styles.activeGroup : ''}`}>
               <label>Artist</label>
               <input type="text" value={localFilters.artist} onChange={e => setLocalFilters(f => ({ ...f, artist: e.target.value }))} className={styles.input} />
             </div>
-            <div className={styles.formGroup}>
+            <div className={`${styles.formGroup} ${titleActive ? styles.activeGroup : ''}`}>
               <label>Song</label>
               <input type="text" value={localFilters.title} onChange={e => setLocalFilters(f => ({ ...f, title: e.target.value }))} className={styles.input} />
             </div>
-            <div className={styles.formGroup}>
+            <div className={`${styles.formGroup} ${gamesActive ? styles.activeGroup : ''}`}>
               <label>Game Versions</label>
               <div className={styles.gameCheckboxes}>
                 {games.map(game => {
@@ -143,7 +152,7 @@ const FilterModal = ({ isOpen, onClose, games, showLists, onCreateList }) => {
                 })}
               </div>
             </div>
-            <div className={styles.formGroup}>
+            <div className={`${styles.formGroup} ${multiBpmActive ? styles.activeGroup : ''}`}>
               <label>Multiple BPMs</label>
               <select value={localFilters.multiBpm} onChange={e => setLocalFilters(f => ({ ...f, multiBpm: e.target.value }))} className={styles.select}>
                 <option value="any">Any</option>

--- a/src/components/FilterModal.module.css
+++ b/src/components/FilterModal.module.css
@@ -112,6 +112,12 @@
     color: white;
 }
 
+.activeGroup {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+    border-radius: 0.5rem;
+}
+
 
 
 .checkboxLabel input {


### PR DESCRIPTION
## Summary
- add accent outline when a filter has values
- apply the outline across all filter groups

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877ef6b41588326b82a14243ee88460