### PR TITLE
Fix scroll reset on BPM page

### DIFF
--- a/src/BPMTool.jsx
+++ b/src/BPMTool.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useContext, useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Line } from 'react-chartjs-2';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler } from 'chart.js';
 import { GoogleGenerativeAI } from "@google/generative-ai";
@@ -176,6 +177,7 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
     const { targetBPM, multipliers, apiKey, playStyle, setPlayStyle, showLists } = useContext(SettingsContext);
     const { filters, resetFilters } = useFilters();
     const { groups, addChartToGroup, createGroup, addChartsToGroup } = useGroups();
+    const location = useLocation();
     const [songOptions, setSongOptions] = useState([]);
     const [inputValue, setInputValue] = useState('');
     const [isProcessing, setIsProcessing] = useState(false);
@@ -215,6 +217,12 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
         window.addEventListener('resize', handleResize);
         return () => window.removeEventListener('resize', handleResize);
     }, []);
+
+    useEffect(() => {
+        if (location.state?.fromSongCard) {
+            window.scrollTo(0, 0);
+        }
+    }, [location.state?.fromSongCard]);
 
     useEffect(() => {
         fetch('/song-meta.json')

--- a/src/components/SongCard.jsx
+++ b/src/components/SongCard.jsx
@@ -78,7 +78,10 @@ const SongCard = ({ song, setSelectedGame, resetFilters, onRemove }) => {
     <div className="song-card-link" onClick={() => {
       if (resetFilters) resetFilters();
       if (setPlayStyle) setPlayStyle(song.mode);
-      navigate(`/bpm?difficulty=${song.difficulty}&mode=${song.mode}#${encodeURIComponent(song.title)}`);
+      navigate(
+        `/bpm?difficulty=${song.difficulty}&mode=${song.mode}#${encodeURIComponent(song.title)}`,
+        { state: { fromSongCard: true } }
+      );
     }}>
       <div className="song-card">
         {onRemove && (


### PR DESCRIPTION
## Summary
- ensure BPM page scrolls to top when reached from a song card
- pass navigation state from `SongCard` on click

## Testing
- `npm run lint` *(fails: Fast refresh/unused var errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877f043c4e08326af2b78ac5e4b0af2