### PR TITLE
Adjust mobile layout for action buttons

### DIFF
--- a/src/BPMTool.css
+++ b/src/BPMTool.css
@@ -38,6 +38,14 @@
     align-items: center;
 }
 
+.mobile-only {
+    display: none;
+}
+
+.desktop-only {
+    display: flex;
+}
+
 
 .song-select-container {
     flex-grow: 1;
@@ -549,6 +557,14 @@
         order: 2;
         flex-grow: 1;
     }
+
+    .mobile-only {
+        display: none;
+    }
+
+    .desktop-only {
+        display: flex;
+    }
 }
 
 .play-mode-toggle {
@@ -593,6 +609,14 @@
 
     .play-style-toggle {
         order: 3;
+    }
+
+    .mobile-only {
+        display: flex;
+    }
+
+    .desktop-only {
+        display: none;
     }
 }
 

--- a/src/BPMTool.jsx
+++ b/src/BPMTool.jsx
@@ -698,6 +698,17 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
                             <button onClick={() => setView(v => v === 'bpm' ? 'chart' : 'bpm')} className={view === 'bpm' ? 'active' : ''}>BPM</button>
                             <button onClick={() => setView(v => v === 'bpm' ? 'chart' : 'bpm')} className={view === 'chart' ? 'active' : ''}>Chart</button>
                         </div>
+                        <div className="action-buttons mobile-only">
+                            {apiKey && <Camera onCapture={sendToGemini} isProcessing={isProcessing} />}
+                            {showLists && (
+                                <button className="filter-button" onClick={handleAddToList} title="Add to list">
+                                    <i className="fa-solid fa-plus"></i>
+                                </button>
+                            )}
+                            <button className={`filter-button ${filtersActive ? 'active' : ''}`} onClick={() => setShowFilter(true)}>
+                                <i className="fa-solid fa-filter"></i>
+                            </button>
+                        </div>
                     </div>
                     <div className="song-search-row">
                         <div className="song-select-container">
@@ -720,7 +731,7 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
                                 }}
                             />
                         </div>
-                        <div className="action-buttons">
+                        <div className="action-buttons desktop-only">
                             {apiKey && <Camera onCapture={sendToGemini} isProcessing={isProcessing} />}
                             {showLists && (
                                 <button className="filter-button" onClick={handleAddToList} title="Add to list">


### PR DESCRIPTION
## Summary
- move action buttons to top row on mobile by duplicating markup
- add CSS classes to toggle which set of buttons is shown

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68782c5da9a4832681fd94bd7fb91373