### PR TITLE
Add chart editing and beginner badge

### DIFF
--- a/src/ListsPage.css
+++ b/src/ListsPage.css
@@ -74,6 +74,25 @@
   background-color: rgba(0, 0, 0, 0.1);
 }
 
+.edit-charts-button {
+  background: none;
+  border: none;
+  color: var(--text-color);
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s;
+}
+
+.edit-charts-button.active,
+.edit-charts-button:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
 .color-picker-label {
   position: relative;
   cursor: pointer;

--- a/src/ListsPage.css
+++ b/src/ListsPage.css
@@ -31,6 +31,10 @@
   font-size: 1rem;
   transition: background-color 0.2s;
 }
+.filter-button.active {
+  background-color: var(--accent-color);
+  color: var(--text-color);
+}
 
 .dan-header {
   display: flex;

--- a/src/ListsPage.jsx
+++ b/src/ListsPage.jsx
@@ -3,14 +3,14 @@ import SongCard from './components/SongCard.jsx';
 import { useGroups } from './contexts/GroupsContext.jsx';
 import { useFilters } from './contexts/FilterContext.jsx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTrash, faPalette, faPlus, faPen, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faTrash, faPalette, faPlus, faPen } from '@fortawesome/free-solid-svg-icons';
 import CreateListModal from './components/CreateListModal.jsx';
 import EditChartModal from './components/EditChartModal.jsx';
 import './App.css';
 import './VegaPage.css';
 import './ListsPage.css';
 
-const GroupSection = ({ group, removeChart, deleteGroup, updateColor, updateName, resetFilters, onEditChart, showEdit, showDelete, highlightKey }) => {
+const GroupSection = ({ group, removeChart, deleteGroup, updateColor, updateName, resetFilters, onEditChart, highlightKey }) => {
   const [isCollapsed, setIsCollapsed] = useState(() => {
     try {
       return JSON.parse(localStorage.getItem(`dan-header-collapsed-${group.name}`)) || false;
@@ -20,6 +20,7 @@ const GroupSection = ({ group, removeChart, deleteGroup, updateColor, updateName
   });
   const [isEditing, setIsEditing] = useState(false);
   const [name, setName] = useState(group.name);
+  const [showActions, setShowActions] = useState(false);
 
   useEffect(() => {
     localStorage.setItem(`dan-header-collapsed-${group.name}`, JSON.stringify(isCollapsed));
@@ -62,6 +63,13 @@ const GroupSection = ({ group, removeChart, deleteGroup, updateColor, updateName
           <button onClick={handleDelete} className="delete-list-button">
             <FontAwesomeIcon icon={faTrash} />
           </button>
+          <button
+            className={`edit-charts-button${showActions ? ' active' : ''}`}
+            onClick={() => setShowActions(prev => !prev)}
+            title="Edit charts"
+          >
+            <FontAwesomeIcon icon={faPen} />
+          </button>
           {isEditing ? (
             <input
               className="list-name-input"
@@ -88,8 +96,8 @@ const GroupSection = ({ group, removeChart, deleteGroup, updateColor, updateName
                 key={idx}
                 song={chart}
                 resetFilters={resetFilters}
-                onRemove={showDelete ? () => removeChart(group.name, chart) : undefined}
-                onEdit={showEdit ? () => onEditChart(group.name, chart) : undefined}
+                onRemove={showActions ? () => removeChart(group.name, chart) : undefined}
+                onEdit={showActions ? () => onEditChart(group.name, chart) : undefined}
                 highlight={highlightKey === key}
               />
             );
@@ -119,8 +127,6 @@ const ListsPage = () => {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [songMeta, setSongMeta] = useState([]);
   const [editInfo, setEditInfo] = useState(null); // { groupName, chart }
-  const [editMode, setEditMode] = useState(false);
-  const [deleteMode, setDeleteMode] = useState(false);
   const [highlightKey, setHighlightKey] = useState(null);
 
   useEffect(() => {
@@ -183,20 +189,6 @@ const ListsPage = () => {
             >
               <FontAwesomeIcon icon={faPlus} />
             </button>
-            <button
-              className={`filter-button ${editMode ? 'active' : ''}`}
-              onClick={() => setEditMode(prev => !prev)}
-              title="Toggle edit mode"
-            >
-              <FontAwesomeIcon icon={faPen} />
-            </button>
-            <button
-              className={`filter-button ${deleteMode ? 'active' : ''}`}
-              onClick={() => setDeleteMode(prev => !prev)}
-              title="Toggle delete mode"
-            >
-              <FontAwesomeIcon icon={faTimes} />
-            </button>
           </div>
         </div>
         {groupsToShow.map(g => (
@@ -209,8 +201,6 @@ const ListsPage = () => {
             updateName={updateGroupName}
             resetFilters={resetFilters}
             onEditChart={(groupName, chart) => setEditInfo({ groupName, chart })}
-            showEdit={editMode}
-            showDelete={deleteMode}
             highlightKey={highlightKey}
           />
         ))}

--- a/src/components/EditChartModal.jsx
+++ b/src/components/EditChartModal.jsx
@@ -1,22 +1,30 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import styles from './AddToListModal.module.css';
 
 const EditChartModal = ({ isOpen, onClose, chart, options, onSave }) => {
   const [selected, setSelected] = useState(chart?.difficulty || '');
+  const scrollRef = useRef(0);
 
   useEffect(() => {
-    if (isOpen) {
-      setSelected(chart?.difficulty || '');
-      const sbWidth = window.innerWidth - document.documentElement.clientWidth;
-      document.body.style.overflow = 'hidden';
-      document.body.style.paddingRight = `${sbWidth}px`;
-    } else {
-      document.body.style.overflow = '';
-      document.body.style.paddingRight = '';
-    }
+    if (!isOpen) return;
+    setSelected(chart?.difficulty || '');
+    scrollRef.current = window.scrollY;
+    const sbWidth = window.innerWidth - document.documentElement.clientWidth;
+    document.body.style.overflow = 'hidden';
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollRef.current}px`;
+    document.body.style.left = '0';
+    document.body.style.right = '0';
+    document.body.style.paddingRight = `${sbWidth}px`;
     return () => {
+      const y = scrollRef.current;
       document.body.style.overflow = '';
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.left = '';
+      document.body.style.right = '';
       document.body.style.paddingRight = '';
+      window.scrollTo(0, y);
     };
   }, [isOpen, chart]);
 

--- a/src/components/EditChartModal.jsx
+++ b/src/components/EditChartModal.jsx
@@ -4,15 +4,28 @@ import styles from './AddToListModal.module.css';
 const EditChartModal = ({ isOpen, onClose, chart, options, onSave }) => {
   const [selected, setSelected] = useState(chart?.difficulty || '');
 
+  const [scrollPos, setScrollPos] = useState(0);
+
   useEffect(() => {
     if (isOpen) {
       setSelected(chart?.difficulty || '');
+      const y = window.scrollY;
+      setScrollPos(y);
+      document.body.style.position = 'fixed';
+      document.body.style.top = `-${y}px`;
       document.body.style.overflow = 'hidden';
     } else {
+      document.body.style.position = '';
+      document.body.style.top = '';
       document.body.style.overflow = 'unset';
+      window.scrollTo(0, scrollPos);
     }
-    return () => { document.body.style.overflow = 'unset'; };
-  }, [isOpen, chart]);
+    return () => {
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen, chart, scrollPos]);
 
   if (!isOpen || !chart) return null;
 

--- a/src/components/EditChartModal.jsx
+++ b/src/components/EditChartModal.jsx
@@ -4,38 +4,21 @@ import styles from './AddToListModal.module.css';
 const EditChartModal = ({ isOpen, onClose, chart, options, onSave }) => {
   const [selected, setSelected] = useState(chart?.difficulty || '');
 
-  const [scrollPos, setScrollPos] = useState(0);
-
   useEffect(() => {
     if (isOpen) {
       setSelected(chart?.difficulty || '');
-      const y = window.scrollY;
-      setScrollPos(y);
       const sbWidth = window.innerWidth - document.documentElement.clientWidth;
-      document.body.style.position = 'fixed';
-      document.body.style.top = `-${y}px`;
-      document.body.style.left = '0';
-      document.body.style.right = '0';
-      document.body.style.paddingRight = `${sbWidth}px`;
       document.body.style.overflow = 'hidden';
+      document.body.style.paddingRight = `${sbWidth}px`;
     } else {
-      document.body.style.position = '';
-      document.body.style.top = '';
-      document.body.style.left = '';
-      document.body.style.right = '';
+      document.body.style.overflow = '';
       document.body.style.paddingRight = '';
-      document.body.style.overflow = 'unset';
-      window.scrollTo(0, scrollPos);
     }
     return () => {
-      document.body.style.position = '';
-      document.body.style.top = '';
-      document.body.style.left = '';
-      document.body.style.right = '';
+      document.body.style.overflow = '';
       document.body.style.paddingRight = '';
-      document.body.style.overflow = 'unset';
     };
-  }, [isOpen, chart, scrollPos]);
+  }, [isOpen, chart]);
 
   if (!isOpen || !chart) return null;
 

--- a/src/components/EditChartModal.jsx
+++ b/src/components/EditChartModal.jsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+import styles from './AddToListModal.module.css';
+
+const EditChartModal = ({ isOpen, onClose, chart, options, onSave }) => {
+  const [selected, setSelected] = useState(chart?.difficulty || '');
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelected(chart?.difficulty || '');
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+    return () => { document.body.style.overflow = 'unset'; };
+  }, [isOpen, chart]);
+
+  if (!isOpen || !chart) return null;
+
+  const handleSave = () => {
+    const opt = options.find(o => o.difficulty === selected);
+    if (opt) {
+      onSave(opt);
+    }
+    onClose();
+  };
+
+  return (
+    <div className={styles.modalBackdrop} onClick={onClose}>
+      <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
+        <h3 className={styles.modalHeader}>Edit Difficulty</h3>
+        <div className={styles.modalBody}>
+          <div className={styles.formGroup}>
+            <label>Difficulty</label>
+            <select
+              value={selected}
+              onChange={e => setSelected(e.target.value)}
+              className={styles.select}
+            >
+              {options.map(o => (
+                <option key={o.difficulty} value={o.difficulty}>
+                  {o.difficulty} (Lv.{o.feet})
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div className={styles.buttonGroup}>
+          <button onClick={onClose} className={`${styles.button} ${styles.cancelButton}`}>Cancel</button>
+          <button onClick={handleSave} className={`${styles.button} ${styles.applyButton}`}>Save</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EditChartModal;

--- a/src/components/EditChartModal.jsx
+++ b/src/components/EditChartModal.jsx
@@ -11,18 +11,28 @@ const EditChartModal = ({ isOpen, onClose, chart, options, onSave }) => {
       setSelected(chart?.difficulty || '');
       const y = window.scrollY;
       setScrollPos(y);
+      const sbWidth = window.innerWidth - document.documentElement.clientWidth;
       document.body.style.position = 'fixed';
       document.body.style.top = `-${y}px`;
+      document.body.style.left = '0';
+      document.body.style.right = '0';
+      document.body.style.paddingRight = `${sbWidth}px`;
       document.body.style.overflow = 'hidden';
     } else {
       document.body.style.position = '';
       document.body.style.top = '';
+      document.body.style.left = '';
+      document.body.style.right = '';
+      document.body.style.paddingRight = '';
       document.body.style.overflow = 'unset';
       window.scrollTo(0, scrollPos);
     }
     return () => {
       document.body.style.position = '';
       document.body.style.top = '';
+      document.body.style.left = '';
+      document.body.style.right = '';
+      document.body.style.paddingRight = '';
       document.body.style.overflow = 'unset';
     };
   }, [isOpen, chart, scrollPos]);

--- a/src/components/SongCard.css
+++ b/src/components/SongCard.css
@@ -121,3 +121,13 @@
   background-color: var(--button-down-color);
   color: white;
 }
+
+.song-card.highlight {
+  box-shadow: 0 0 0 3px var(--accent-color);
+  animation: highlight-fade 1.5s forwards;
+}
+
+@keyframes highlight-fade {
+  from { box-shadow: 0 0 0 3px var(--accent-color); }
+  to { box-shadow: none; }
+}

--- a/src/components/SongCard.css
+++ b/src/components/SongCard.css
@@ -113,6 +113,10 @@
   padding: 0.25rem;
   cursor: pointer;
 }
+.song-card-action.edit {
+  background-color: var(--difficulty-edit-color);
+  right: 2rem;
+}
 .song-card-action.remove {
   background-color: var(--button-down-color);
   color: white;

--- a/src/components/SongCard.jsx
+++ b/src/components/SongCard.jsx
@@ -2,17 +2,19 @@ import React, { useMemo, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SettingsContext } from '../contexts/SettingsContext.jsx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faTimes, faPen } from '@fortawesome/free-solid-svg-icons';
 import './SongCard.css';
 
 const difficultyDisplayMap = {
     single: {
+        beginner: { name: "BGN", color: "#4DB6AC", textColor: "#000000" },
         basic: { name: "BSP", color: "#f8d45a", textColor: "#000000" },
         difficult: { name: "DSP", color: "#d4504e", textColor: "#ffffff" },
         expert: { name: "ESP", color: "#6fbe44", textColor: "#ffffff" },
         challenge: { name: "CSP", color: "#c846a6", textColor: "#ffffff" },
     },
     double: {
+        beginner: { name: "BGD", color: "#4DB6AC", textColor: "#000000" },
         basic: { name: "BDP", color: "#f8d45a", textColor: "#000000" },
         difficult: { name: "DDP", color: "#d4504e", textColor: "#ffffff" },
         expert: { name: "EDP", color: "#6fbe44", textColor: "#ffffff" },
@@ -29,7 +31,7 @@ const getBpmRange = (bpm) => {
   return { min: Math.min(...parts), max: Math.max(...parts) };
 };
 
-const SongCard = ({ song, resetFilters, onRemove }) => {
+const SongCard = ({ song, resetFilters, onRemove, onEdit }) => {
   const { targetBPM, multipliers, setPlayStyle } = useContext(SettingsContext);
   const navigate = useNavigate();
 
@@ -84,8 +86,13 @@ const SongCard = ({ song, resetFilters, onRemove }) => {
       );
     }}>
       <div className="song-card">
+        {onEdit && (
+          <button className="song-card-action edit" onClick={(e) => { e.stopPropagation(); onEdit(); }}>
+            <FontAwesomeIcon icon={faPen} />
+          </button>
+        )}
         {onRemove && (
-          <button className="song-card-action" onClick={(e) => { e.stopPropagation(); onRemove(); }}>
+          <button className="song-card-action remove" onClick={(e) => { e.stopPropagation(); onRemove(); }}>
             <FontAwesomeIcon icon={faTimes} />
           </button>
         )}

--- a/src/components/SongCard.jsx
+++ b/src/components/SongCard.jsx
@@ -7,15 +7,15 @@ import './SongCard.css';
 
 const difficultyDisplayMap = {
     single: {
-        beginner: { name: "BGN", color: "#4DB6AC", textColor: "#000000" },
-        basic: { name: "bSP", color: "#f8d45a", textColor: "#000000" },
+        beginner: { name: "bSP", color: "#4DB6AC", textColor: "#000000" },
+        basic: { name: "BSP", color: "#f8d45a", textColor: "#000000" },
         difficult: { name: "DSP", color: "#d4504e", textColor: "#ffffff" },
         expert: { name: "ESP", color: "#6fbe44", textColor: "#ffffff" },
         challenge: { name: "CSP", color: "#c846a6", textColor: "#ffffff" },
     },
     double: {
-        beginner: { name: "BGD", color: "#4DB6AC", textColor: "#000000" },
-        basic: { name: "bDP", color: "#f8d45a", textColor: "#000000" },
+        beginner: { name: "bDP", color: "#4DB6AC", textColor: "#000000" },
+        basic: { name: "BDP", color: "#f8d45a", textColor: "#000000" },
         difficult: { name: "DDP", color: "#d4504e", textColor: "#ffffff" },
         expert: { name: "EDP", color: "#6fbe44", textColor: "#ffffff" },
         challenge: { name: "CDP", color: "#c846a6", textColor: "#ffffff" },

--- a/src/components/SongCard.jsx
+++ b/src/components/SongCard.jsx
@@ -8,14 +8,14 @@ import './SongCard.css';
 const difficultyDisplayMap = {
     single: {
         beginner: { name: "BGN", color: "#4DB6AC", textColor: "#000000" },
-        basic: { name: "BSP", color: "#f8d45a", textColor: "#000000" },
+        basic: { name: "bSP", color: "#f8d45a", textColor: "#000000" },
         difficult: { name: "DSP", color: "#d4504e", textColor: "#ffffff" },
         expert: { name: "ESP", color: "#6fbe44", textColor: "#ffffff" },
         challenge: { name: "CSP", color: "#c846a6", textColor: "#ffffff" },
     },
     double: {
         beginner: { name: "BGD", color: "#4DB6AC", textColor: "#000000" },
-        basic: { name: "BDP", color: "#f8d45a", textColor: "#000000" },
+        basic: { name: "bDP", color: "#f8d45a", textColor: "#000000" },
         difficult: { name: "DDP", color: "#d4504e", textColor: "#ffffff" },
         expert: { name: "EDP", color: "#6fbe44", textColor: "#ffffff" },
         challenge: { name: "CDP", color: "#c846a6", textColor: "#ffffff" },
@@ -31,7 +31,7 @@ const getBpmRange = (bpm) => {
   return { min: Math.min(...parts), max: Math.max(...parts) };
 };
 
-const SongCard = ({ song, resetFilters, onRemove, onEdit }) => {
+const SongCard = ({ song, resetFilters, onRemove, onEdit, highlight = false }) => {
   const { targetBPM, multipliers, setPlayStyle } = useContext(SettingsContext);
   const navigate = useNavigate();
 
@@ -85,7 +85,7 @@ const SongCard = ({ song, resetFilters, onRemove, onEdit }) => {
         { state: { fromSongCard: true } }
       );
     }}>
-      <div className="song-card">
+      <div className={`song-card${highlight ? ' highlight' : ''}`}>
         {onEdit && (
           <button className="song-card-action edit" onClick={(e) => { e.stopPropagation(); onEdit(); }}>
             <FontAwesomeIcon icon={faPen} />

--- a/src/contexts/GroupsContext.jsx
+++ b/src/contexts/GroupsContext.jsx
@@ -84,6 +84,17 @@ export const GroupsProvider = ({ children }) => {
     } : g));
   };
 
+  const updateChartDifficulty = (name, chart, newDiff) => {
+    setGroups(prev => prev.map(g => g.name === name ? {
+      ...g,
+      charts: g.charts.map(c =>
+        c.title === chart.title && c.mode === chart.mode && c.difficulty === chart.difficulty
+          ? { ...c, difficulty: newDiff.difficulty.toLowerCase(), level: newDiff.feet }
+          : c
+      )
+    } : g));
+  };
+
   return (
     <GroupsContext.Provider value={{
       groups,
@@ -94,6 +105,7 @@ export const GroupsProvider = ({ children }) => {
       updateGroupColor,
       addChartsToGroup,
       updateGroupName,
+      updateChartDifficulty,
       activeGroup,
       setActiveGroup,
     }}>


### PR DESCRIPTION
## Summary
- allow editing a chart's difficulty on the list page
- show an edit button on each song card
- support editing difficulty level through new modal
- add beginner difficulty abbreviations so basic charts show correctly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878cd0180a48326bc5c0c838e6cf3ee