### PR TITLE
Enable sticky Dan headers on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -467,6 +467,13 @@ body {
         flex-grow: 1;
         min-width: 150px;
     }
+
+    /* Keep open section headers visible while scrolling */
+    .dan-header:not(.is-collapsed) {
+        position: sticky;
+        top: 0;
+        z-index: 5;
+    }
 }
 
 .difficulty-beginner { background-color: var(--difficulty-beginner-color); }


### PR DESCRIPTION
## Summary
- keep open `.dan-header` elements sticky on small screens

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879ff4bb534832692bf196675407f04