### PR TITLE
Add D1 DB config and schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,14 @@ You will need [Node.js](https://nodejs.org/en/) installed on your machine.
     ```
 
 The application will now be running locally, typically at `http://localhost:5173`.
+
+## Database Setup
+
+This project includes a sample `wrangler.toml` configured for a Cloudflare D1 database.
+After creating the database, run the schema using:
+
+```sh
+wrangler d1 execute ddr-toolkit --file=./schema.sql
+```
+
+Replace `ddr-toolkit` with your database name if different. This command will create the `users` table defined in `schema.sql`.

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,7 @@
+-- Schema for the DDR Toolkit database
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE,
+    hashed_password TEXT NOT NULL,
+    settings JSON
+);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+[[d1_databases]]
+binding = "DB"
+database_name = "ddr-toolkit"


### PR DESCRIPTION
## Summary
- configure Cloudflare D1 database in `wrangler.toml`
- add `schema.sql` with a `users` table
- document database initialization in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a2f8f772c83269fe9afad1e318275