### PR TITLE
Add auth context and login route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,15 +7,18 @@ import Settings from './Settings';
 import { SettingsProvider, SettingsContext } from './contexts/SettingsContext.jsx';
 import { FilterProvider, useFilters } from './contexts/FilterContext.jsx';
 import { GroupsProvider } from './contexts/GroupsContext.jsx';
+import { AuthProvider, AuthContext } from './contexts/AuthContext.jsx';
 import { findSongByTitle, loadSimfileData } from './utils/simfile-loader.js';
 import DanPage from './DanPage.jsx';
 import VegaPage from './VegaPage.jsx';
 import ListsPage from './ListsPage.jsx';
+import Login from './Login.jsx';
 import './App.css';
 import './Tabs.css';
 
 function AppRoutes() {
   const { theme, showLists, setPlayStyle, songlistOverride } = useContext(SettingsContext);
+  const { isAuthenticated } = useContext(AuthContext);
   const [smData, setSmData] = useState({ games: [], files: [] });
   const [simfileData, setSimfileData] = useState(null);
   const [currentChart, setCurrentChart] = useState(null);
@@ -142,13 +145,20 @@ function AppRoutes() {
       <div className="app-container">
         <div className="app-content">
           <Routes>
-            <Route path="/dan" element={<DanPage activeDan={activeDan} setActiveDan={setActiveDan} setSelectedGame={setSelectedGame} />} />
-            <Route path="/vega" element={<VegaPage activeVegaCourse={activeVegaCourse} setActiveVegaCourse={setActiveVegaCourse} setSelectedGame={setSelectedGame} />} />
-          <Route path="/multiplier" element={<Multiplier />} />
-          {showLists && <Route path="/lists" element={<ListsPage />} />}
-          <Route path="/" element={<Navigate to="/bpm" replace />} />
-            <Route path="/bpm" element={<BPMTool smData={smData} simfileData={simfileData} currentChart={currentChart} setCurrentChart={handleChartSelect} onSongSelect={handleSongSelect} selectedGame={selectedGame} setSelectedGame={setSelectedGame} view={view} setView={setView} />} />
-            <Route path="/settings" element={<Settings />} />
+            <Route path="/login" element={isAuthenticated ? <Navigate to="/bpm" replace /> : <Login />} />
+            {isAuthenticated ? (
+              <>
+                <Route path="/dan" element={<DanPage activeDan={activeDan} setActiveDan={setActiveDan} setSelectedGame={setSelectedGame} />} />
+                <Route path="/vega" element={<VegaPage activeVegaCourse={activeVegaCourse} setActiveVegaCourse={setActiveVegaCourse} setSelectedGame={setSelectedGame} />} />
+                <Route path="/multiplier" element={<Multiplier />} />
+                {showLists && <Route path="/lists" element={<ListsPage />} />}
+                <Route path="/" element={<Navigate to="/bpm" replace />} />
+                <Route path="/bpm" element={<BPMTool smData={smData} simfileData={simfileData} currentChart={currentChart} setCurrentChart={handleChartSelect} onSongSelect={handleSongSelect} selectedGame={selectedGame} setSelectedGame={setSelectedGame} view={view} setView={setView} />} />
+                <Route path="/settings" element={<Settings />} />
+              </>
+            ) : (
+              <Route path="*" element={<Navigate to="/login" replace />} />
+            )}
           </Routes>
         </div>
         <footer className="footer">
@@ -161,15 +171,17 @@ function AppRoutes() {
 
 function AppWrapper() {
   return (
-    <SettingsProvider>
-      <FilterProvider>
-        <GroupsProvider>
-          <Router>
-            <AppRoutes />
-          </Router>
-        </GroupsProvider>
-      </FilterProvider>
-    </SettingsProvider>
+    <AuthProvider>
+      <SettingsProvider>
+        <FilterProvider>
+          <GroupsProvider>
+            <Router>
+              <AppRoutes />
+            </Router>
+          </GroupsProvider>
+        </FilterProvider>
+      </SettingsProvider>
+    </AuthProvider>
   );
 }
 

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -1,0 +1,85 @@
+import React, { useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from './contexts/AuthContext.jsx';
+import { SettingsContext } from './contexts/SettingsContext.jsx';
+import './Settings.css';
+
+const Login = () => {
+  const { login } = useContext(AuthContext);
+  const settingsCtx = useContext(SettingsContext);
+  const navigate = useNavigate();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const applySettings = (data) => {
+    if (data.targetBPM !== undefined) settingsCtx.setTargetBPM(data.targetBPM);
+    if (data.multiplierMode) settingsCtx.setMultiplierMode(data.multiplierMode);
+    if (data.theme) settingsCtx.setTheme(data.theme);
+    if (data.playStyle) settingsCtx.setPlayStyle(data.playStyle);
+    if (data.showLists !== undefined) settingsCtx.setShowLists(data.showLists);
+    if (data.songlistOverride) settingsCtx.setSonglistOverride(data.songlistOverride);
+    if (data.apiKey) settingsCtx.setApiKey(data.apiKey);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const token = await login(email, password);
+      const res = await fetch('/api/settings', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        applySettings(data);
+      }
+      navigate('/bpm');
+    } catch {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <div className="app-container">
+      <div className="settings-content">
+        <form onSubmit={handleSubmit} className="settings-inner-container">
+          <div className="setting-card">
+            <div className="setting-text">
+              <h3>Email</h3>
+            </div>
+            <div className="setting-control">
+              <input
+                type="email"
+                className="settings-input"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+          <div className="setting-card">
+            <div className="setting-text">
+              <h3>Password</h3>
+            </div>
+            <div className="setting-control">
+              <input
+                type="password"
+                className="settings-input"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+          {error && <div className="setting-text" style={{color:'red'}}>{error}</div>}
+          <button type="submit" className="settings-button">Login</button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Login;
+

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,48 @@
+/* eslint react-refresh/only-export-components: off */
+import React, { createContext, useState } from 'react';
+
+export const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(() => sessionStorage.getItem('authToken'));
+  const [user, setUser] = useState(() => {
+    const saved = sessionStorage.getItem('authUser');
+    return saved ? JSON.parse(saved) : null;
+  });
+
+  const login = async (email, password) => {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (!res.ok) {
+      throw new Error('Login failed');
+    }
+    const data = await res.json();
+    setToken(data.token);
+    sessionStorage.setItem('authToken', data.token);
+    const newUser = { email };
+    setUser(newUser);
+    sessionStorage.setItem('authUser', JSON.stringify(newUser));
+    return data.token;
+  };
+
+  const logout = () => {
+    setToken(null);
+    setUser(null);
+    sessionStorage.removeItem('authToken');
+    sessionStorage.removeItem('authUser');
+  };
+
+  const value = {
+    token,
+    user,
+    login,
+    logout,
+    isAuthenticated: !!token,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+


### PR DESCRIPTION
## Summary
- create an `AuthContext` for handling tokens and user state
- add a `Login` component that fetches settings on success
- protect app routes with authentication checks
- wrap app in `AuthProvider` for global auth state

## Testing
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_687a317db23c83268995a05425291bea