### PR TITLE
Add register page

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,19 @@ wrangler d1 execute ddr-toolkit --file=./schema.sql
 ```
 
 Replace `ddr-toolkit` with your database name if different. This command will create the `users` table defined in `schema.sql`.
+
+## Cloudflare Deployment
+
+1. **Create a D1 database** in your Cloudflare account and note the ID and name.
+   Update `wrangler.toml` with these values under the `[[d1_databases]]` block.
+2. **Set the JWT secret** used for signing tokens:
+   ```sh
+   wrangler secret put JWT_SECRET
+   ```
+   Choose a long random value when prompted.
+3. **Apply the schema** to the new database:
+   ```sh
+   wrangler d1 execute <your-db-name> --file=./schema.sql
+   ```
+4. Deploy the project with `wrangler deploy`.
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import DanPage from './DanPage.jsx';
 import VegaPage from './VegaPage.jsx';
 import ListsPage from './ListsPage.jsx';
 import Login from './Login.jsx';
+import Register from './Register.jsx';
 import './App.css';
 import './Tabs.css';
 
@@ -146,6 +147,7 @@ function AppRoutes() {
         <div className="app-content">
           <Routes>
             <Route path="/login" element={isAuthenticated ? <Navigate to="/bpm" replace /> : <Login />} />
+            <Route path="/register" element={isAuthenticated ? <Navigate to="/bpm" replace /> : <Register />} />
             {isAuthenticated ? (
               <>
                 <Route path="/dan" element={<DanPage activeDan={activeDan} setActiveDan={setActiveDan} setSelectedGame={setSelectedGame} />} />


### PR DESCRIPTION
## Summary
- allow users to sign up with a new `Register` page
- add a route for `/register`
- link to the registration page from the login screen
- document Cloudflare deployment setup for the D1 database and JWT secret

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a4b1e125c83269894b480257bcd74