### PR TITLE
Migrate to Cloudflare Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,14 @@ You will need [Node.js](https://nodejs.org/en/) installed on your machine.
     ```
 
 The application will now be running locally, typically at `http://localhost:5173`.
+
+## Deploying to Cloudflare Workers
+
+This project is configured for [Cloudflare Workers](https://developers.cloudflare.com/workers/).
+Install the `wrangler` CLI and run `wrangler publish` to deploy the built assets.
+
+```sh
+npm install -g wrangler
+wrangler publish
+```
+

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,5 @@
+export default {
+  async fetch(request, env) {
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,9 @@
+name = "ddr-toolkit"
+main = "worker.js"
+compatibility_date = "2024-05-01"
+
+[build]
+command = "npm run build"
+
+[site]
+bucket = "./dist"


### PR DESCRIPTION
## Summary
- add a Cloudflare Workers entry script
- configure wrangler for static site deployment
- document how to publish with wrangler

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a73547bcc8326a6f8ce8ef7e9b4a9