### PR TITLE
Fix worker asset loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,7 @@ npm install -g wrangler
 wrangler publish
 ```
 
+If you preview the Worker in the Cloudflare dashboard, ensure the build was
+deployed with `wrangler publish` (or run `wrangler dev` locally) so the `ASSETS`
+binding is available.
+

--- a/worker.js
+++ b/worker.js
@@ -1,5 +1,8 @@
 export default {
   async fetch(request, env) {
-    return env.ASSETS.fetch(request);
+    if (env.ASSETS && typeof env.ASSETS.fetch === 'function') {
+      return env.ASSETS.fetch(request);
+    }
+    return new Response('ASSETS binding missing', { status: 500 });
   },
 };


### PR DESCRIPTION
## Summary
- handle missing `ASSETS` binding gracefully
- note that assets require `wrangler publish` or dev for preview

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b758f08888326931ae063b208b58d