### PR TITLE
Fix SPA routing with worker fallback

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,8 +1,21 @@
 export default {
   async fetch(request, env) {
     if (env.ASSETS && typeof env.ASSETS.fetch === 'function') {
-      return env.ASSETS.fetch(request);
+      let response = await env.ASSETS.fetch(request);
+
+      // If the asset was not found and the path doesn't look like a file,
+      // fall back to serving the SPA entry point so client-side routing works.
+      if (
+        response.status === 404 &&
+        !new URL(request.url).pathname.includes('.')
+      ) {
+        const indexRequest = new Request(new URL('/index.html', request.url), request);
+        response = await env.ASSETS.fetch(indexRequest);
+      }
+
+      return response;
     }
+
     return new Response('ASSETS binding missing', { status: 500 });
   },
 };


### PR DESCRIPTION
## Summary
- ensure unknown routes fall back to `index.html`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b823d09ac8326b5ec572a59f7f6d1