### PR TITLE
Fix worker SPA routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ ganymede.png
 songs.png
 /_archive
 public/song-meta.json
+.wrangler/

--- a/worker.js
+++ b/worker.js
@@ -9,7 +9,8 @@ export default {
     // For requests that look like SPA routes (no file extension), always serve
     // the main index file so the front-end router can resolve the path.
     if (request.method === 'GET' && !url.pathname.includes('.')) {
-      return env.ASSETS.fetch(new Request('/index.html', request));
+      const indexUrl = new URL('/index.html', url);
+      return env.ASSETS.fetch(new Request(indexUrl.toString(), request));
     }
 
     // Otherwise treat as a normal static asset request.


### PR DESCRIPTION
## Summary
- handle SPA index request with absolute URL so Cloudflare doesn't throw Error 1101
- ignore temporary `.wrangler/` files

## Testing
- `npm run build`
- `wrangler build` *(dry run)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b8b9d559c83268adf88827b1558a5