### PR TITLE
Switch to Hono routing for Cloudflare Worker SPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,16 @@ You will need [Node.js](https://nodejs.org/en/) installed on your machine.
     ```
 
 The application will now be running locally, typically at `http://localhost:5173`.
+
+## Deploying to Cloudflare Workers
+
+This project uses a Cloudflare Worker to serve the built React application and expose a simple API powered by the [Hono](https://hono.dev/) framework.
+
+1.  Build and deploy using Wrangler:
+    ```sh
+    npm run deploy
+    ```
+
+2.  The worker exposes an example endpoint at `/api/hello` returning a greeting in JSON.
+
+The Worker configuration in `wrangler.jsonc` sets `not_found_handling` to `single_page_application` so that React Router can handle client-side routes.

--- a/_worker.js
+++ b/_worker.js
@@ -1,5 +1,11 @@
-export default {
-  async fetch(request, env) {
-    return env.ASSETS.fetch(request);
-  },
-};
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+app.get('/api/hello', (c) => c.json({ message: 'Hello from Hono!' }))
+
+app.use('*', async (c) => {
+  return c.env.ASSETS.fetch(c.req.raw)
+})
+
+export default app

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "chart.js": "^4.5.0",
         "clsx": "^2.1.1",
         "fraction.js": "^4.0.13",
+        "hono": "^3.11.0",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
@@ -3122,6 +3123,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "3.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-3.12.12.tgz",
+      "integrity": "sha512-5IAMJOXfpA5nT+K0MNjClchzz0IhBHs2Szl7WFAhrFOsbtQsYmNynFyJRg/a3IPsmCfxcrf8txUGiNShXpK5Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
     "react-select": "^5.10.1",
-    "react-window": "^1.8.11"
+    "react-window": "^1.8.11",
+    "hono": "^3.11.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,7 +4,8 @@
   "compatibility_date": "2025-06-05",
   "assets": {
     "directory": "./dist",
-    "binding": "ASSETS"
+    "binding": "ASSETS",
+    "not_found_handling": "single_page_application"
   },
   "build": {
     "command": "npm run build"


### PR DESCRIPTION
## Summary
- add `hono` package
- implement Worker with Hono routing and static asset fallback
- enable SPA behavior in `wrangler.jsonc`
- document deployment via Cloudflare Workers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687bc57fe8e48326bd679d0567a055df