### PR TITLE
Fix ranked rating display in BPM tool

### DIFF
--- a/src/BPMTool.css
+++ b/src/BPMTool.css
@@ -301,6 +301,10 @@
     gap: 0.5rem;
 }
 
+.difficulty-meters-container.ranked .difficulty-meter {
+    width: 60px;
+}
+
 .difficulty-meter {
     padding: 0.3rem 0.5rem;
     width: 40px;

--- a/src/BPMTool.jsx
+++ b/src/BPMTool.jsx
@@ -323,8 +323,8 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
         let data = null;
         let length = 0;
 
-        if (currentChart && simfileData.charts) {
-            const chartDetails = simfileData.charts[currentChart.slug];
+        if (currentChart && simfileWithRatings.charts) {
+            const chartDetails = simfileWithRatings.charts[currentChart.slug];
             if (chartDetails) {
                 const bpmChanges = chartDetails.bpm;
                 const lastBeat = getLastBeat(chartDetails);
@@ -347,16 +347,16 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
         }
 
         return {
-            songTitle: simfileData.title.titleName,
-            artist: simfileData.artist,
-            gameVersion: simfileData.mix.mixName,
+            songTitle: simfileWithRatings.title.titleName,
+            artist: simfileWithRatings.artist,
+            gameVersion: simfileWithRatings.mix.mixName,
             difficulties: diffs,
             bpmDisplay: display,
             coreBpm: core,
             chartData: data,
             songLength: length,
         };
-    }, [simfileData, currentChart]);
+    }, [simfileWithRatings, currentChart]);
 
     const calculation = useMemo(() => {
         if (!targetBPM || !bpmDisplay || bpmDisplay === 'N/A') return null;

--- a/src/components/SongInfoBar.jsx
+++ b/src/components/SongInfoBar.jsx
@@ -109,7 +109,7 @@ const SongInfoBar = ({
         <div className="details-grid bpm-tool-grid">
           <div className={`grid-item difficulty-container ${playStyle === 'single' ? 'grid-item-sp' : 'grid-item-dp'}`}>
               <span className="difficulty-label">Difficulty:</span>
-              <div className="difficulty-meters-container">
+              <div className={`difficulty-meters-container${showRankedRatings ? ' ranked' : ''}`}>
                 {renderDifficulties(playStyle)}
               </div>
           </div>


### PR DESCRIPTION
## Summary
- ensure BPM tool recomputes details when ranked metadata loads
- adjust difficulty meter layout when ranked ratings shown
- allow difficulty meters container to widen for decimal ratings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687be648705c8326a1c3a8b11fb0bac1