### PR TITLE
Make rankings always available

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ import './App.css';
 import './Tabs.css';
 
 function AppRoutes() {
-  const { theme, showLists, showRankedRatings, setPlayStyle, songlistOverride } = useContext(SettingsContext);
+  const { theme, showLists, setPlayStyle, songlistOverride } = useContext(SettingsContext);
   const [smData, setSmData] = useState({ games: [], files: [] });
   const [simfileData, setSimfileData] = useState(null);
   const [currentChart, setCurrentChart] = useState(null);
@@ -146,7 +146,7 @@ function AppRoutes() {
             <Route path="/dan" element={<DanPage activeDan={activeDan} setActiveDan={setActiveDan} setSelectedGame={setSelectedGame} />} />
             <Route path="/vega" element={<VegaPage activeVegaCourse={activeVegaCourse} setActiveVegaCourse={setActiveVegaCourse} setSelectedGame={setSelectedGame} />} />
           <Route path="/multiplier" element={<Multiplier />} />
-          {showRankedRatings && <Route path="/rankings" element={<RankingsPage />} />}
+          <Route path="/rankings" element={<RankingsPage />} />
           {showLists && <Route path="/lists" element={<ListsPage />} />}
           <Route path="/" element={<Navigate to="/bpm" replace />} />
             <Route path="/bpm" element={<BPMTool smData={smData} simfileData={simfileData} currentChart={currentChart} setCurrentChart={handleChartSelect} onSongSelect={handleSongSelect} selectedGame={selectedGame} setSelectedGame={setSelectedGame} view={view} setView={setView} />} />

--- a/src/RankingsPage.jsx
+++ b/src/RankingsPage.jsx
@@ -18,7 +18,7 @@ const RatingSection = ({ rating, charts }) => {
       {!isCollapsed && (
         <div className="song-grid">
           {charts.map((chart, idx) => (
-            <SongCard key={idx} song={chart} />
+            <SongCard key={idx} song={chart} forceShowRankedRating />
           ))}
         </div>
       )}

--- a/src/Settings.css
+++ b/src/Settings.css
@@ -51,6 +51,13 @@
     font-size: 0.875rem;
 }
 
+.settings-sub-header {
+    margin: 2rem 0 1rem 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    text-align: center;
+}
+
 .setting-control {
     display: flex;
     width: 100%;

--- a/src/Settings.jsx
+++ b/src/Settings.jsx
@@ -105,6 +105,8 @@ const Settings = () => {
                         </div>
                     </div>
 
+                    <h2 className="settings-sub-header">Beta Features</h2>
+
                     <div className="setting-card">
                         <div className="setting-text">
                             <h3>Google AI Studio API Key</h3>

--- a/src/Tabs.jsx
+++ b/src/Tabs.jsx
@@ -13,7 +13,7 @@ const Logo = () => (
 
 const Tabs = () => {
     const location = useLocation();
-    const { playStyle, setPlayStyle, showLists, showRankedRatings } = useContext(SettingsContext);
+    const { playStyle, setPlayStyle, showLists } = useContext(SettingsContext);
 
     return (
         <nav className="tabs-container">
@@ -35,11 +35,9 @@ const Tabs = () => {
                     <NavLink to={`/multiplier${location.hash}`} className={({ isActive }) => (isActive ? 'tab active' : 'tab')}>
                         <FontAwesomeIcon icon={faCalculator} />
                     </NavLink>
-                    {showRankedRatings && (
-                        <NavLink to={`/rankings${location.hash}`} className={({ isActive }) => (isActive ? 'tab active' : 'tab')}>
-                            <FontAwesomeIcon icon={faRankingStar} />
-                        </NavLink>
-                    )}
+                    <NavLink to={`/rankings${location.hash}`} className={({ isActive }) => (isActive ? 'tab active' : 'tab')}>
+                        <FontAwesomeIcon icon={faRankingStar} />
+                    </NavLink>
                     {showLists && (
                         <NavLink to={`/lists${location.hash}`} className={({ isActive }) => (isActive ? 'tab active' : 'tab')}>
                             <FontAwesomeIcon icon={faList} />

--- a/src/components/SongCard.jsx
+++ b/src/components/SongCard.jsx
@@ -31,7 +31,7 @@ const getBpmRange = (bpm) => {
   return { min: Math.min(...parts), max: Math.max(...parts) };
 };
 
-const SongCard = ({ song, resetFilters, onRemove, onEdit, highlight = false }) => {
+const SongCard = ({ song, resetFilters, onRemove, onEdit, highlight = false, forceShowRankedRating = false }) => {
   const { targetBPM, multipliers, setPlayStyle, showRankedRatings } = useContext(SettingsContext);
   const navigate = useNavigate();
 
@@ -76,6 +76,8 @@ const SongCard = ({ song, resetFilters, onRemove, onEdit, highlight = false }) =
     );
   }
 
+  const showRanked = forceShowRankedRating || showRankedRatings;
+
   return (
     <div className="song-card-link" onClick={() => {
       if (resetFilters) resetFilters();
@@ -112,7 +114,7 @@ const SongCard = ({ song, resetFilters, onRemove, onEdit, highlight = false }) =
             </div>
           </div>
           <div className="song-level-container">
-              <span className="song-level">Lv.{showRankedRatings && song.rankedRating ? song.rankedRating.toFixed(1) : song.level}</span>
+              <span className="song-level">Lv.{showRanked && song.rankedRating ? song.rankedRating.toFixed(1) : song.level}</span>
               {difficultyInfo && (
                    <span 
                       className="difficulty-badge"


### PR DESCRIPTION
## Summary
- show the /rankings tab regardless of settings
- enable the /rankings route at all times
- allow SongCard to force ranked difficulty display
- show decimal difficulties on RankingsPage
- rearrange Settings page with new Beta Features section

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687cbf0f9b1c83268d25b720dcda66ed