### PR TITLE
Fix level state persistence and rating display

### DIFF
--- a/src/RankingsPage.jsx
+++ b/src/RankingsPage.jsx
@@ -30,7 +30,10 @@ const RankingsPage = () => {
   const { playStyle } = useContext(SettingsContext);
   const { resetFilters } = useFilters();
   const [songMeta, setSongMeta] = useState([]);
-  const [selectedLevel, setSelectedLevel] = useState(null);
+  const [selectedLevel, setSelectedLevel] = useState(() => {
+    const stored = localStorage.getItem('selectedRankingLevel');
+    return stored ? Number(stored) : null;
+  });
 
   useEffect(() => {
     fetch('/song-meta.json')
@@ -52,10 +55,21 @@ const RankingsPage = () => {
   }, [songMeta, playStyle]);
 
   useEffect(() => {
-    if (availableLevels.length > 0 && !availableLevels.includes(selectedLevel)) {
+    if (availableLevels.length === 0) return;
+    if (selectedLevel == null) {
+      const stored = localStorage.getItem('selectedRankingLevel');
+      const level = stored ? Number(stored) : availableLevels[0];
+      setSelectedLevel(availableLevels.includes(level) ? level : availableLevels[0]);
+    } else if (!availableLevels.includes(selectedLevel)) {
       setSelectedLevel(availableLevels[0]);
     }
-  }, [availableLevels, selectedLevel]);
+  }, [availableLevels]);
+
+  useEffect(() => {
+    if (selectedLevel != null) {
+      localStorage.setItem('selectedRankingLevel', selectedLevel);
+    }
+  }, [selectedLevel]);
 
   const chartsForLevel = useMemo(() => {
     const charts = [];

--- a/src/components/EditChartModal.jsx
+++ b/src/components/EditChartModal.jsx
@@ -54,7 +54,7 @@ const EditChartModal = ({ isOpen, onClose, chart, options, onSave }) => {
             >
               {options.map(o => (
                 <option key={o.difficulty} value={o.difficulty}>
-                  {o.difficulty} (Lv.{showRankedRatings && o.rankedRating != null ? o.rankedRating.toFixed(1) : o.feet})
+                  {o.difficulty} (Lv.{showRankedRatings && o.rankedRating != null ? o.rankedRating : o.feet})
                 </option>
               ))}
             </select>

--- a/src/components/SongCard.jsx
+++ b/src/components/SongCard.jsx
@@ -114,7 +114,7 @@ const SongCard = ({ song, resetFilters, onRemove, onEdit, highlight = false, for
             </div>
           </div>
           <div className="song-level-container">
-              <span className="song-level">Lv.{showRanked && song.rankedRating ? song.rankedRating.toFixed(1) : song.level}</span>
+              <span className="song-level">Lv.{showRanked && song.rankedRating != null ? song.rankedRating : song.level}</span>
               {difficultyInfo && (
                    <span 
                       className="difficulty-badge"

--- a/src/components/StepchartPage.jsx
+++ b/src/components/StepchartPage.jsx
@@ -104,7 +104,7 @@ export function StepchartPage({
 
 
   const title = currentTypeMeta
-    ? `${displaySimfile.title.translitTitleName || displaySimfile.title.titleName} - ${currentType.replace(/-/g, ", ")} (${showRankedRatings && currentTypeMeta.rankedRating != null ? currentTypeMeta.rankedRating.toFixed(1) : currentTypeMeta.feet})`
+    ? `${displaySimfile.title.translitTitleName || displaySimfile.title.titleName} - ${currentType.replace(/-/g, ", ")} (${showRankedRatings && currentTypeMeta.rankedRating != null ? currentTypeMeta.rankedRating : currentTypeMeta.feet})`
     : displaySimfile.title.titleName;
 
 

--- a/src/components/StepchartViewer.jsx
+++ b/src/components/StepchartViewer.jsx
@@ -93,7 +93,7 @@ const StepchartViewer = ({ smFileUrl }) => {
       <select onChange={handleChartChange} value={selectedChartKey || ''}>
         {simfile.availableTypes.map((chartType) => (
           <option key={chartType.slug} value={chartType.slug}>
-            {chartType.mode} - {chartType.difficulty} ({showRankedRatings && chartType.rankedRating != null ? chartType.rankedRating.toFixed(1) : chartType.feet})
+            {chartType.mode} - {chartType.difficulty} ({showRankedRatings && chartType.rankedRating != null ? chartType.rankedRating : chartType.feet})
           </option>
         ))}
       </select>


### PR DESCRIPTION
## Summary
- persist ranking level selection with localStorage
- show ranked rating values without rounding across the app

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cc14430a8832699bc3d6e5af215c9