### PR TITLE
Update hono to mitigate vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "chart.js": "^4.5.0",
         "clsx": "^2.1.1",
         "fraction.js": "^4.0.13",
-        "hono": "^3.11.0",
+        "hono": "^4.8.5",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
@@ -3126,12 +3126,12 @@
       }
     },
     "node_modules/hono": {
-      "version": "3.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-3.12.12.tgz",
-      "integrity": "sha512-5IAMJOXfpA5nT+K0MNjClchzz0IhBHs2Szl7WFAhrFOsbtQsYmNynFyJRg/a3IPsmCfxcrf8txUGiNShXpK5Rg==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.8.5.tgz",
+      "integrity": "sha512-Up2cQbtNz1s111qpnnECdTGqSIUIhZJMLikdKkshebQSEBcoUKq6XJayLGqSZWidiH0zfHRCJqFu062Mz5UuRA==",
       "license": "MIT",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-router-dom": "^7.6.3",
     "react-select": "^5.10.1",
     "react-window": "^1.8.11",
-    "hono": "^3.11.0"
+    "hono": "^4.8.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",


### PR DESCRIPTION
## Summary
- bump hono from 3.x to 4.8.5

## Testing
- `npm audit | head -n 20`
- `npm run build >/tmp/build.log && tail -n 20 /tmp/build.log`


------
https://chatgpt.com/codex/tasks/task_e_687ccce59fd48326a0701c78af25ee2b