### PR TITLE
Add sorting toggle to ranking page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ import './App.css';
 import './Tabs.css';
 
 function AppRoutes() {
-  const { theme, showLists, setPlayStyle, songlistOverride } = useContext(SettingsContext);
+  const { theme, showLists, setPlayStyle, songlistOverride, playStyle } = useContext(SettingsContext);
   const [smData, setSmData] = useState({ games: [], files: [] });
   const [simfileData, setSimfileData] = useState(null);
   const [currentChart, setCurrentChart] = useState(null);

--- a/src/RankingsPage.jsx
+++ b/src/RankingsPage.jsx
@@ -2,8 +2,11 @@ import React, { useState, useEffect, useContext, useMemo } from 'react';
 import SongCard from './components/SongCard.jsx';
 import { SettingsContext } from './contexts/SettingsContext.jsx';
 import { useFilters } from './contexts/FilterContext.jsx';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowDownWideShort, faArrowUpWideShort } from '@fortawesome/free-solid-svg-icons';
 import './App.css';
 import './VegaPage.css';
+import './ListsPage.css';
 
 const RatingSection = ({ rating, charts }) => {
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -33,6 +36,10 @@ const RankingsPage = () => {
   const [selectedLevel, setSelectedLevel] = useState(() => {
     const stored = localStorage.getItem('selectedRankingLevel');
     return stored ? Number(stored) : null;
+  });
+  const [ascendingOrder, setAscendingOrder] = useState(() => {
+    const stored = localStorage.getItem('rankingsAscending');
+    return stored ? JSON.parse(stored) : false;
   });
 
   useEffect(() => {
@@ -71,6 +78,10 @@ const RankingsPage = () => {
     }
   }, [selectedLevel]);
 
+  useEffect(() => {
+    localStorage.setItem('rankingsAscending', JSON.stringify(ascendingOrder));
+  }, [ascendingOrder]);
+
   const chartsForLevel = useMemo(() => {
     const charts = [];
     for (const song of songMeta) {
@@ -104,9 +115,11 @@ const RankingsPage = () => {
       if (!map.has(ratingKey)) map.set(ratingKey, []);
       map.get(ratingKey).push(chart);
     }
-    const keys = Array.from(map.keys()).sort((a, b) => b - a);
+    const keys = Array.from(map.keys()).sort((a, b) =>
+      ascendingOrder ? a - b : b - a
+    );
     return keys.map(k => ({ rating: k, charts: map.get(k) }));
-  }, [chartsForLevel]);
+  }, [chartsForLevel, ascendingOrder]);
 
   if (!selectedLevel) return null;
 
@@ -122,6 +135,13 @@ const RankingsPage = () => {
                 ))}
               </select>
             </div>
+            <button
+              className="filter-button"
+              onClick={() => setAscendingOrder(a => !a)}
+              title="Flip order"
+            >
+              <FontAwesomeIcon icon={ascendingOrder ? faArrowUpWideShort : faArrowDownWideShort} />
+            </button>
           </div>
         </div>
         {groupedCharts.map(group => (


### PR DESCRIPTION
## Summary
- add Font Awesome icon imports for new control
- persist ranking order preference
- provide button to flip ranking order
- expose `playStyle` in `AppRoutes` for lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ce3d15e108326862e9be2b8a3022b