### PR TITLE
Add modal close buttons and sort reset

### DIFF
--- a/src/components/AddToListModal.jsx
+++ b/src/components/AddToListModal.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import styles from './AddToListModal.module.css';
 
 const AddToListModal = ({ isOpen, onClose, groups, onAdd }) => {
@@ -28,6 +30,9 @@ const AddToListModal = ({ isOpen, onClose, groups, onAdd }) => {
   return (
     <div className={styles.modalBackdrop} onClick={onClose}>
       <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
+        <button className={styles.closeButton} onClick={onClose} aria-label="Close">
+          <FontAwesomeIcon icon={faTimes} />
+        </button>
         <h3 className={styles.modalHeader}>Add Chart to List</h3>
         <div className={styles.modalBody}>
           <div className={styles.formGroup}>
@@ -57,7 +62,6 @@ const AddToListModal = ({ isOpen, onClose, groups, onAdd }) => {
           </div>
         </div>
         <div className={styles.buttonGroup}>
-          <button onClick={onClose} className={`${styles.button} ${styles.cancelButton}`}>Cancel</button>
           <button onClick={handleAdd} className={`${styles.button} ${styles.applyButton}`}>Add</button>
         </div>
       </div>

--- a/src/components/AddToListModal.module.css
+++ b/src/components/AddToListModal.module.css
@@ -23,6 +23,7 @@
     flex-direction: column;
     gap: 1rem;
     max-height: 90vh;
+    position: relative;
 }
 
 .modalHeader {
@@ -85,6 +86,22 @@
     color: var(--text-color);
 }
 
+.resetButton {
+    background-color: var(--button-bg);
+    color: var(--button-icon);
+}
+
+.closeButton {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: transparent;
+    border: none;
+    color: var(--text-color);
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
 @media (max-width: 1024px) {
     .modalBackdrop {
         align-items: flex-start;
@@ -105,6 +122,10 @@
     .modalHeader {
         padding-top: env(safe-area-inset-top, 1.5rem);
         text-align: center;
+    }
+
+    .closeButton {
+        top: calc(env(safe-area-inset-top, 0) + 0.5rem);
     }
 
     .modalBody {

--- a/src/components/CreateListModal.jsx
+++ b/src/components/CreateListModal.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import styles from './AddToListModal.module.css';
 
 const CreateListModal = ({ isOpen, onClose, onCreate }) => {
@@ -29,6 +31,9 @@ const CreateListModal = ({ isOpen, onClose, onCreate }) => {
   return (
     <div className={styles.modalBackdrop} onClick={onClose}>
       <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
+        <button className={styles.closeButton} onClick={onClose} aria-label="Close">
+          <FontAwesomeIcon icon={faTimes} />
+        </button>
         <h3 className={styles.modalHeader}>Create New List</h3>
         <div className={styles.modalBody}>
           <div className={styles.formGroup}>
@@ -43,7 +48,6 @@ const CreateListModal = ({ isOpen, onClose, onCreate }) => {
           </div>
         </div>
         <div className={styles.buttonGroup}>
-          <button onClick={onClose} className={`${styles.button} ${styles.cancelButton}`}>Cancel</button>
           <button onClick={handleCreate} className={`${styles.button} ${styles.applyButton}`}>Create</button>
         </div>
       </div>

--- a/src/components/EditChartModal.jsx
+++ b/src/components/EditChartModal.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef, useContext } from 'react';
 import { SettingsContext } from '../contexts/SettingsContext.jsx';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import styles from './AddToListModal.module.css';
 
 const EditChartModal = ({ isOpen, onClose, chart, options, onSave }) => {
@@ -43,6 +45,9 @@ const EditChartModal = ({ isOpen, onClose, chart, options, onSave }) => {
   return (
     <div className={styles.modalBackdrop} onClick={onClose}>
       <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
+        <button className={styles.closeButton} onClick={onClose} aria-label="Close">
+          <FontAwesomeIcon icon={faTimes} />
+        </button>
         <h3 className={styles.modalHeader}>Edit Difficulty</h3>
         <div className={styles.modalBody}>
           <div className={styles.formGroup}>
@@ -61,7 +66,6 @@ const EditChartModal = ({ isOpen, onClose, chart, options, onSave }) => {
           </div>
         </div>
         <div className={styles.buttonGroup}>
-          <button onClick={onClose} className={`${styles.button} ${styles.cancelButton}`}>Cancel</button>
           <button onClick={handleSave} className={`${styles.button} ${styles.applyButton}`}>Save</button>
         </div>
       </div>

--- a/src/components/FilterModal.jsx
+++ b/src/components/FilterModal.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useFilters } from '../contexts/FilterContext.jsx';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import styles from './FilterModal.module.css';
 
 const difficultyNames = ['Beginner', 'Basic', 'Difficult', 'Expert', 'Challenge'];
@@ -83,6 +85,9 @@ const FilterModal = ({ isOpen, onClose, games, showLists, onCreateList }) => {
   return (
     <div className={styles.modalBackdrop} onClick={onClose}>
       <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
+        <button className={styles.closeButton} onClick={onClose} aria-label="Close">
+          <FontAwesomeIcon icon={faTimes} />
+        </button>
         <h3 className={styles.modalHeader}>Song Filters</h3>
         <div className={styles.modalBody}>
           <div className={styles.column}>
@@ -235,7 +240,6 @@ const FilterModal = ({ isOpen, onClose, games, showLists, onCreateList }) => {
           )}
           <div className={styles.rightButtons}>
             <button onClick={reset} className={`${styles.button} ${styles.resetButton}`}>Reset</button>
-            <button onClick={onClose} className={`${styles.button} ${styles.cancelButton}`}>Cancel</button>
             <button onClick={apply} className={`${styles.button} ${styles.applyButton}`}>Apply</button>
           </div>
         </div>

--- a/src/components/FilterModal.module.css
+++ b/src/components/FilterModal.module.css
@@ -25,6 +25,7 @@
     flex-direction: column;
     gap: 1rem;
     max-height: 90vh;
+    position: relative;
 }
 
 .modalHeader {
@@ -176,6 +177,17 @@
     color: var(--text-color);
 }
 
+.closeButton {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: transparent;
+    border: none;
+    color: var(--text-color);
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
 .createListButton {
     background-color: var(--button-up-color);
     color: white;
@@ -216,12 +228,17 @@
         justify-content: space-between;
         box-sizing: border-box;
         background-color: var(--bg-color-light); /* Unify background color */
-        
+        position: relative;
+
     }
 
     .modalHeader {
         padding-top: env(safe-area-inset-top, 1.5rem);
         text-align:center;
+    }
+
+    .closeButton {
+        top: calc(env(safe-area-inset-top, 0) + 0.5rem);
     }
 
     .modalBody {

--- a/src/components/SortModal.jsx
+++ b/src/components/SortModal.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import styles from './AddToListModal.module.css';
 
 const SORT_OPTIONS = [
@@ -33,9 +35,17 @@ const SortModal = ({ isOpen, onClose, sortKey, setSortKey, ascending, setAscendi
     onClose();
   };
 
+  const reset = () => {
+    setLocalKey('title');
+    setLocalAsc(true);
+  };
+
   return (
     <div className={styles.modalBackdrop} onClick={onClose}>
       <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
+        <button className={styles.closeButton} onClick={onClose} aria-label="Close">
+          <FontAwesomeIcon icon={faTimes} />
+        </button>
         <h3 className={styles.modalHeader}>Sort Songs</h3>
         <div className={styles.modalBody}>
           <div className={styles.formGroup}>
@@ -55,7 +65,7 @@ const SortModal = ({ isOpen, onClose, sortKey, setSortKey, ascending, setAscendi
           </div>
         </div>
         <div className={styles.buttonGroup}>
-          <button onClick={onClose} className={`${styles.button} ${styles.cancelButton}`}>Cancel</button>
+          <button onClick={reset} className={`${styles.button} ${styles.resetButton}`}>Reset</button>
           <button onClick={apply} className={`${styles.button} ${styles.applyButton}`}>Apply</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add close icons to all modals
- support reset button for song sort dialog
- update modal styles for new close button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687cf5166b2883268a75665c56d5bf43