### PR TITLE
Add Cloudflare login with D1 storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ public/song-meta.json
 public/dan-data.json
 public/song-meta.json
 public/vega-data.json
+dist

--- a/_worker.js
+++ b/_worker.js
@@ -1,8 +1,101 @@
 import { Hono } from 'hono'
+import { sign, verify } from 'hono/jwt'
+import bcrypt from 'bcryptjs'
 
 const app = new Hono()
 
+const JWT_SECRET = 'ddr-toolkit-secret'
+
+const initDB = async (db) => {
+  await db.exec(`CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE,
+    password TEXT
+  );`)
+  await db.exec(`CREATE TABLE IF NOT EXISTS settings (
+    user_id INTEGER PRIMARY KEY,
+    data TEXT
+  );`)
+  await db.exec(`CREATE TABLE IF NOT EXISTS lists (
+    user_id INTEGER PRIMARY KEY,
+    data TEXT
+  );`)
+}
+
 app.get('/api/hello', (c) => c.json({ message: 'Hello from Hono!' }))
+
+app.use('/api/*', async (c, next) => {
+  c.res.headers.set('Access-Control-Allow-Origin', '*')
+  c.res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  if (c.req.method === 'OPTIONS') return c.text('')
+  await next()
+})
+
+app.post('/api/register', async c => {
+  const { username, password } = await c.req.json()
+  if (!username || !password) return c.json({ error: 'invalid' }, 400)
+  await initDB(c.env.DB)
+  const hash = await bcrypt.hash(password, 10)
+  try {
+    const result = await c.env.DB.prepare('INSERT INTO users (username, password) VALUES (?, ?)').bind(username, hash).run()
+    const id = result.meta.last_row_id
+    const token = await sign({ id, username }, JWT_SECRET)
+    return c.json({ token })
+  } catch {
+    return c.json({ error: 'user exists' }, 400)
+  }
+})
+
+app.post('/api/login', async c => {
+  const { username, password } = await c.req.json()
+  await initDB(c.env.DB)
+  const user = await c.env.DB.prepare('SELECT * FROM users WHERE username = ?').bind(username).first()
+  if (!user) return c.json({ error: 'invalid' }, 400)
+  const ok = await bcrypt.compare(password, user.password)
+  if (!ok) return c.json({ error: 'invalid' }, 400)
+  const token = await sign({ id: user.id, username }, JWT_SECRET)
+  return c.json({ token })
+})
+
+const auth = async c => {
+  const header = c.req.header('Authorization')
+  if (!header) return null
+  const token = header.split(' ')[1]
+  try {
+    return await verify(token, JWT_SECRET)
+  } catch {
+    return null
+  }
+}
+
+app.get('/api/user', async c => {
+  const payload = await auth(c)
+  if (!payload) return c.json({ error: 'unauthorized' }, 401)
+  await initDB(c.env.DB)
+  const settingsRow = await c.env.DB.prepare('SELECT data FROM settings WHERE user_id = ?').bind(payload.id).first()
+  const listsRow = await c.env.DB.prepare('SELECT data FROM lists WHERE user_id = ?').bind(payload.id).first()
+  return c.json({ user: { username: payload.username }, settings: settingsRow ? JSON.parse(settingsRow.data) : null, lists: listsRow ? JSON.parse(listsRow.data) : null })
+})
+
+app.post('/api/settings', async c => {
+  const payload = await auth(c)
+  if (!payload) return c.json({ error: 'unauthorized' }, 401)
+  const body = await c.req.json()
+  await initDB(c.env.DB)
+  const data = JSON.stringify(body.settings)
+  await c.env.DB.prepare('INSERT INTO settings (user_id, data) VALUES (?, ?) ON CONFLICT(user_id) DO UPDATE SET data=excluded.data').bind(payload.id, data).run()
+  return c.json({ ok: true })
+})
+
+app.post('/api/lists', async c => {
+  const payload = await auth(c)
+  if (!payload) return c.json({ error: 'unauthorized' }, 401)
+  const body = await c.req.json()
+  await initDB(c.env.DB)
+  const data = JSON.stringify(body.lists)
+  await c.env.DB.prepare('INSERT INTO lists (user_id, data) VALUES (?, ?) ON CONFLICT(user_id) DO UPDATE SET data=excluded.data').bind(payload.id, data).run()
+  return c.json({ ok: true })
+})
 
 app.use('*', async (c) => {
   return c.env.ASSETS.fetch(c.req.raw)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@google/generative-ai": "^0.24.1",
+        "bcryptjs": "^2.4.3",
         "chart.js": "^4.5.0",
         "clsx": "^2.1.1",
         "fraction.js": "^4.0.13",
@@ -2330,6 +2331,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
     "node_modules/blake3-wasm": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-router-dom": "^7.6.3",
     "react-select": "^5.10.1",
     "react-window": "^1.8.11",
-    "hono": "^4.8.5"
+    "hono": "^4.8.5",
+    "bcryptjs": "^2.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Settings from './Settings';
 import { SettingsProvider, SettingsContext } from './contexts/SettingsContext.jsx';
 import { FilterProvider, useFilters } from './contexts/FilterContext.jsx';
 import { GroupsProvider } from './contexts/GroupsContext.jsx';
+import { UserProvider } from './contexts/UserContext.jsx';
 import { findSongByTitle, loadSimfileData } from './utils/simfile-loader.js';
 import DanPage from './DanPage.jsx';
 import VegaPage from './VegaPage.jsx';
@@ -176,9 +177,11 @@ function AppWrapper() {
     <SettingsProvider>
       <FilterProvider>
         <GroupsProvider>
-          <Router>
-            <AppRoutes />
-          </Router>
+          <UserProvider>
+            <Router>
+              <AppRoutes />
+            </Router>
+          </UserProvider>
         </GroupsProvider>
       </FilterProvider>
     </SettingsProvider>

--- a/src/Settings.css
+++ b/src/Settings.css
@@ -101,6 +101,13 @@
     background-color: var(--accent-color-light);
 }
 
+.login-form {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    gap: 0.5rem;
+}
+
 /* Mobile Layout */
 @media (max-width: 1024px) {
     .settings-content {

--- a/src/Settings.jsx
+++ b/src/Settings.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from 'react';
+import { useUser } from './contexts/UserContext.jsx';
 import { SettingsContext } from './contexts/SettingsContext.jsx';
 import { MULTIPLIER_MODES } from './utils/multipliers';
 import { SONGLIST_OVERRIDE_OPTIONS } from './utils/songlistOverrides';
@@ -20,6 +21,7 @@ const Settings = () => {
         songlistOverride,
         setSonglistOverride,
     } = useContext(SettingsContext);
+    const { user, login, logout, register } = useUser();
 
     const [newApiKey, setNewApiKey] = useState(apiKey);
 
@@ -103,6 +105,45 @@ const Settings = () => {
                         </div>
                     </div>
                     <ThemeSwitcher />
+
+                    <div className="setting-card">
+                        <div className="setting-text">
+                            <h3>Account</h3>
+                            {user ? (
+                                <p>Logged in as {user.username}</p>
+                            ) : (
+                                <p>Create an account to sync your settings and lists across devices.</p>
+                            )}
+                        </div>
+                        <div className="setting-control">
+                            {user ? (
+                                <button onClick={logout} className="settings-button">Logout</button>
+                            ) : (
+                                <form
+                                    onSubmit={e => {
+                                        e.preventDefault();
+                                        const form = e.target;
+                                        const username = form.username.value;
+                                        const password = form.password.value;
+                                        login(username, password).catch(() => alert('Login failed'));
+                                    }}
+                                    className="login-form"
+                                >
+                                    <input name="username" placeholder="username" className="settings-input" />
+                                    <input type="password" name="password" placeholder="password" className="settings-input" />
+                                    <div style={{display:'flex',gap:'0.5rem'}}>
+                                        <button type="submit" className="settings-button">Login</button>
+                                        <button type="button" onClick={() => {
+                                            const form = document.querySelector('.login-form');
+                                            const username = form.username.value;
+                                            const password = form.password.value;
+                                            register(username, password).catch(() => alert('Register failed'));
+                                        }} className="settings-button">Register</button>
+                                    </div>
+                                </form>
+                            )}
+                        </div>
+                    </div>
 
                     <h2 className="settings-sub-header">Beta Features</h2>
 

--- a/src/contexts/GroupsContext.jsx
+++ b/src/contexts/GroupsContext.jsx
@@ -98,6 +98,7 @@ export const GroupsProvider = ({ children }) => {
   return (
     <GroupsContext.Provider value={{
       groups,
+      setGroups,
       createGroup,
       deleteGroup,
       addChartToGroup,

--- a/src/contexts/UserContext.jsx
+++ b/src/contexts/UserContext.jsx
@@ -1,0 +1,123 @@
+/* eslint react-refresh/only-export-components: off */
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { SettingsContext } from './SettingsContext.jsx';
+import { GroupsContext } from './GroupsContext.jsx';
+
+export const UserContext = createContext();
+
+export const UserProvider = ({ children }) => {
+  const [token, setToken] = useState(() => localStorage.getItem('authToken'));
+  const [user, setUser] = useState(null);
+
+  const settings = useContext(SettingsContext);
+  const groupsCtx = useContext(GroupsContext);
+
+  const loadUser = useCallback(async (t) => {
+    try {
+      const res = await fetch('/api/user', {
+        headers: { Authorization: `Bearer ${t}` },
+      });
+      if (!res.ok) throw new Error('failed');
+      const data = await res.json();
+      setUser(data.user);
+      if (data.settings) {
+        for (const [k, v] of Object.entries(data.settings)) {
+          const setter = settings[`set${k.charAt(0).toUpperCase() + k.slice(1)}`];
+          if (setter) setter(v);
+        }
+      }
+      if (data.lists) {
+        groupsCtx.setGroups(data.lists);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }, [settings, groupsCtx]);
+
+  useEffect(() => {
+    if (token) {
+      loadUser(token);
+    }
+  }, [token, loadUser]);
+
+  useEffect(() => {
+    if (!token) return;
+    const payload = {
+      settings: {
+        targetBPM: settings.targetBPM,
+        multiplierMode: settings.multiplierMode,
+        theme: settings.theme,
+        playStyle: settings.playStyle,
+        showLists: settings.showLists,
+        showRankedRatings: settings.showRankedRatings,
+        songlistOverride: settings.songlistOverride,
+      },
+    };
+    fetch('/api/settings', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    }).catch(() => {});
+  }, [token, settings.targetBPM, settings.multiplierMode, settings.theme, settings.playStyle, settings.showLists, settings.showRankedRatings, settings.songlistOverride]);
+
+  useEffect(() => {
+    if (!token) return;
+    fetch('/api/lists', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ lists: groupsCtx.groups }),
+    }).catch(() => {});
+  }, [token, groupsCtx.groups]);
+
+  const login = async (username, password) => {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setToken(data.token);
+      localStorage.setItem('authToken', data.token);
+      await loadUser(data.token);
+      return true;
+    }
+    return false;
+  };
+
+  const register = async (username, password) => {
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setToken(data.token);
+      localStorage.setItem('authToken', data.token);
+      await loadUser(data.token);
+      return true;
+    }
+    return false;
+  };
+
+  const logout = async () => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem('authToken');
+  };
+
+  return (
+    <UserContext.Provider value={{ user, token, login, logout, register }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export const useUser = () => useContext(UserContext);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,5 +9,12 @@
   },
   "build": {
     "command": "npm run build"
-  }
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "ddr-toolkit-db",
+      "database_id": "REPLACE_WITH_YOUR_DATABASE_ID"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- implement account system using Cloudflare Worker, D1 and JWT
- store user settings and lists in the database
- sync settings/lists from new `UserContext`
- add login/logout section to the settings page
- expose `setGroups` in `GroupsContext`
- configure D1 in `wrangler.jsonc`
- **fix** missing `database_id` in wrangler configuration
- **fix** linter warning by wrapping `loadUser` with `useCallback`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d585313708326b45b473cd6d5093a