### PR TITLE
Fix D1 initialization for login endpoints

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -11,15 +11,15 @@ const initDB = async (db) => {
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT NOT NULL UNIQUE,
     password TEXT NOT NULL
-  );`);
+  )`);
   await db.exec(`CREATE TABLE IF NOT EXISTS settings (
     user_id INTEGER PRIMARY KEY,
     data TEXT
-  );`);
+  )`);
   await db.exec(`CREATE TABLE IF NOT EXISTS lists (
     user_id INTEGER PRIMARY KEY,
     data TEXT
-  );`);
+  )`);
 };
 
 // Middleware for handling CORS and OPTIONS requests


### PR DESCRIPTION
## Summary
- remove trailing semicolons from the CREATE TABLE statements

The Cloudflare D1 driver was throwing `incomplete input` errors when creating tables. Removing the semicolons resolves the issue so the login and registration routes can work.

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d6ac8c6948326b52a6b6e6dd47b61