### PR TITLE
Add modern login, register and account management

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,8 @@ import Multiplier from './Multiplier';
 import BPMTool from './BPMTool';
 import Tabs from './Tabs';
 import Settings from './Settings';
+import Login from './Login.jsx';
+import Register from './Register.jsx';
 import { SettingsProvider, SettingsContext } from './contexts/SettingsContext.jsx';
 import { FilterProvider, useFilters } from './contexts/FilterContext.jsx';
 import { GroupsProvider } from './contexts/GroupsContext.jsx';
@@ -160,8 +162,10 @@ function AppRoutes() {
           <Route path="/rankings" element={<RankingsPage />} />
           {showLists && <Route path="/lists" element={<ListsPage />} />}
           <Route path="/" element={<Navigate to="/bpm" replace />} />
-            <Route path="/bpm" element={<BPMTool smData={smData} simfileData={simfileData} currentChart={currentChart} setCurrentChart={handleChartSelect} onSongSelect={handleSongSelect} selectedGame={selectedGame} setSelectedGame={setSelectedGame} view={view} setView={setView} />} />
-            <Route path="/settings" element={<Settings />} />
+          <Route path="/bpm" element={<BPMTool smData={smData} simfileData={simfileData} currentChart={currentChart} setCurrentChart={handleChartSelect} onSongSelect={handleSongSelect} selectedGame={selectedGame} setSelectedGame={setSelectedGame} view={view} setView={setView} />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} />
           </Routes>
         </div>
         <footer className="footer">

--- a/src/Auth.css
+++ b/src/Auth.css
@@ -1,0 +1,25 @@
+.auth-content {
+  background-color: var(--bg-color-light);
+  padding: 2rem;
+  margin: 2rem auto;
+  max-width: 400px;
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1);
+  text-align: center;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.auth-message {
+  margin-top: 1rem;
+  color: var(--accent-color);
+}
+
+.auth-link {
+  margin-top: 1rem;
+}

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useUser } from './contexts/UserContext.jsx';
+import './Auth.css';
+
+const Login = () => {
+  const { login } = useUser();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const result = await login(username, password);
+    if (result.success) {
+      setMessage('Login successful.');
+      navigate('/settings');
+    } else {
+      setMessage(result.message || 'Login failed');
+    }
+  };
+
+  return (
+    <div className="app-container">
+      <div className="auth-content">
+        <h2>Login</h2>
+        <form onSubmit={handleSubmit} className="auth-form">
+          <input
+            className="settings-input"
+            placeholder="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <input
+            className="settings-input"
+            type="password"
+            placeholder="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button className="settings-button" type="submit">Login</button>
+        </form>
+        {message && <p className="auth-message">{message}</p>}
+        <p className="auth-link">Don't have an account? <Link to="/register">Register</Link></p>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -12,7 +12,7 @@ const Login = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const result = await login(username, password);
+    const result = await login(username.trim(), password.trim());
     if (result.success) {
       setMessage('Login successful.');
       navigate('/settings');
@@ -31,6 +31,7 @@ const Login = () => {
             placeholder="username"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
           />
           <input
             className="settings-input"
@@ -38,6 +39,7 @@ const Login = () => {
             placeholder="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
           />
           <button className="settings-button" type="submit">Login</button>
         </form>

--- a/src/Register.jsx
+++ b/src/Register.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useUser } from './contexts/UserContext.jsx';
+import './Auth.css';
+
+const Register = () => {
+  const { register } = useUser();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const result = await register(username, password);
+    if (result.success) {
+      setMessage('Registration successful.');
+      navigate('/settings');
+    } else {
+      setMessage(result.message || 'Registration failed');
+    }
+  };
+
+  return (
+    <div className="app-container">
+      <div className="auth-content">
+        <h2>Register</h2>
+        <form onSubmit={handleSubmit} className="auth-form">
+          <input
+            className="settings-input"
+            placeholder="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <input
+            className="settings-input"
+            type="password"
+            placeholder="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button className="settings-button" type="submit">Register</button>
+        </form>
+        {message && <p className="auth-message">{message}</p>}
+        <p className="auth-link">Already have an account? <Link to="/login">Login</Link></p>
+      </div>
+    </div>
+  );
+};
+
+export default Register;

--- a/src/Register.jsx
+++ b/src/Register.jsx
@@ -12,7 +12,7 @@ const Register = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const result = await register(username, password);
+    const result = await register(username.trim(), password.trim());
     if (result.success) {
       setMessage('Registration successful.');
       navigate('/settings');
@@ -31,6 +31,7 @@ const Register = () => {
             placeholder="username"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
           />
           <input
             className="settings-input"
@@ -38,6 +39,7 @@ const Register = () => {
             placeholder="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
           />
           <button className="settings-button" type="submit">Register</button>
         </form>

--- a/src/Settings.jsx
+++ b/src/Settings.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from 'react';
+import { Link } from 'react-router-dom';
 import { useUser } from './contexts/UserContext.jsx';
 import { SettingsContext } from './contexts/SettingsContext.jsx';
 import { MULTIPLIER_MODES } from './utils/multipliers';
@@ -21,7 +22,7 @@ const Settings = () => {
         songlistOverride,
         setSonglistOverride,
     } = useContext(SettingsContext);
-    const { user, login, logout, register } = useUser();
+    const { user, logout } = useUser();
 
     const [newApiKey, setNewApiKey] = useState(apiKey);
     const [testDbResult, setTestDbResult] = useState('');
@@ -135,28 +136,10 @@ const Settings = () => {
                             {user ? (
                                 <button onClick={logout} className="settings-button">Logout</button>
                             ) : (
-                                <form
-                                    onSubmit={e => {
-                                        e.preventDefault();
-                                        const form = e.target;
-                                        const username = form.username.value;
-                                        const password = form.password.value;
-                                        login(username, password).catch(() => alert('Login failed'));
-                                    }}
-                                    className="login-form"
-                                >
-                                    <input name="username" placeholder="username" className="settings-input" />
-                                    <input type="password" name="password" placeholder="password" className="settings-input" />
-                                    <div style={{display:'flex',gap:'0.5rem'}}>
-                                        <button type="submit" className="settings-button">Login</button>
-                                        <button type="button" onClick={() => {
-                                            const form = document.querySelector('.login-form');
-                                            const username = form.username.value;
-                                            const password = form.password.value;
-                                            register(username, password).catch(() => alert('Register failed'));
-                                        }} className="settings-button">Register</button>
-                                    </div>
-                                </form>
+                                <div style={{display:'flex',gap:'0.5rem'}}>
+                                    <Link to="/login" className="settings-button">Login</Link>
+                                    <Link to="/register" className="settings-button">Register</Link>
+                                </div>
                             )}
                         </div>
                     </div>

--- a/src/Tabs.css
+++ b/src/Tabs.css
@@ -96,6 +96,29 @@
     background-color: var(--card-hover-bg-color);
 }
 
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: 0.5rem;
+    color: var(--text-color);
+}
+
+.logout-button {
+    background: none;
+    border: 1px solid var(--accent-color);
+    color: var(--accent-color);
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    font-size: 0.875rem;
+}
+
+.logout-button:hover {
+    background-color: var(--accent-color);
+    color: var(--text-color);
+}
+
 @media (max-width: 640px) {
     .tabs-container {
         margin-bottom:1rem;

--- a/src/Tabs.jsx
+++ b/src/Tabs.jsx
@@ -3,6 +3,7 @@ import { NavLink, useLocation } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCog, faTrophy, faCalculator, faArrowsUpDownLeftRight, faList, faRankingStar } from '@fortawesome/free-solid-svg-icons';
 import { SettingsContext } from './contexts/SettingsContext.jsx';
+import { useUser } from './contexts/UserContext.jsx';
 import './Tabs.css';
 
 const Logo = () => (
@@ -14,6 +15,7 @@ const Logo = () => (
 const Tabs = () => {
     const location = useLocation();
     const { playStyle, setPlayStyle, showLists } = useContext(SettingsContext);
+    const { user, logout } = useUser();
 
     return (
         <nav className="tabs-container">
@@ -50,6 +52,14 @@ const Tabs = () => {
                 <NavLink to={`/settings${location.hash}`} className={({ isActive }) => (isActive ? 'settings-tab active' : 'settings-tab')}>
                     <FontAwesomeIcon icon={faCog} />
                 </NavLink>
+                {user ? (
+                    <div className="user-info">
+                        <span className="username">{user.username}</span>
+                        <button onClick={logout} className="logout-button">Logout</button>
+                    </div>
+                ) : (
+                    <NavLink to="/login" className="settings-tab">Login</NavLink>
+                )}
             </div>
         </nav>
     );

--- a/src/contexts/UserContext.jsx
+++ b/src/contexts/UserContext.jsx
@@ -77,35 +77,45 @@ export const UserProvider = ({ children }) => {
   }, [token, groupsCtx.groups]);
 
   const login = async (username, password) => {
-    const res = await fetch('/api/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password }),
-    });
-    if (res.ok) {
-      const data = await res.json();
-      setToken(data.token);
-      localStorage.setItem('authToken', data.token);
-      await loadUser(data.token);
-      return true;
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setToken(data.token);
+        localStorage.setItem('authToken', data.token);
+        await loadUser(data.token);
+        return { success: true };
+      }
+      const err = await res.json().catch(() => ({}));
+      return { success: false, message: err.error };
+    } catch (e) {
+      return { success: false, message: e.message };
     }
-    return false;
   };
 
   const register = async (username, password) => {
-    const res = await fetch('/api/register', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password }),
-    });
-    if (res.ok) {
-      const data = await res.json();
-      setToken(data.token);
-      localStorage.setItem('authToken', data.token);
-      await loadUser(data.token);
-      return true;
+    try {
+      const res = await fetch('/api/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setToken(data.token);
+        localStorage.setItem('authToken', data.token);
+        await loadUser(data.token);
+        return { success: true };
+      }
+      const err = await res.json().catch(() => ({}));
+      return { success: false, message: err.error };
+    } catch (e) {
+      return { success: false, message: e.message };
     }
-    return false;
   };
 
   const logout = async () => {

--- a/src/contexts/UserContext.jsx
+++ b/src/contexts/UserContext.jsx
@@ -1,5 +1,5 @@
 /* eslint react-refresh/only-export-components: off */
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import { SettingsContext } from './SettingsContext.jsx';
 import { GroupsContext } from './GroupsContext.jsx';
 
@@ -12,7 +12,7 @@ export const UserProvider = ({ children }) => {
   const settings = useContext(SettingsContext);
   const groupsCtx = useContext(GroupsContext);
 
-  const loadUser = async (t) => {
+  const loadUser = useCallback(async (t) => {
     try {
       const res = await fetch('/api/user', {
         headers: { Authorization: `Bearer ${t}` },
@@ -33,7 +33,7 @@ export const UserProvider = ({ children }) => {
     } catch (e) {
       console.error(e);
     }
-  };
+  }, [settings, groupsCtx]);
 
   useEffect(() => {
     if (token) {


### PR DESCRIPTION
## Summary
- add dedicated login and registration pages
- display currently logged in user with logout button in nav bar
- update Settings page to link to login/register
- return status messages from user context
- style new components with `Auth.css`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687dfe0d3d188326aee8397e76111321