### PR TITLE
Add server-side score parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,16 @@ This project uses a Cloudflare Worker to serve the built React application and e
     response is JSON in BATCH-MANUAL format.
 
 4.  The Settings page includes an upload form that sends a Ganymede HTML file to
-    this endpoint and automatically stores the parsed scores locally.
+    this endpoint. Scores parsed as SP or DP are stored separately and will only
+    appear when that play style is selected.
 
 The Worker configuration in `wrangler.jsonc` sets `not_found_handling` to `single_page_application` so that React Router can handle client-side routes.
 
 ### Parsing Scores Locally
 
-Run the following script to convert a Ganymede score HTML file into JSON:
+Run the following script to convert a Ganymede score HTML file into JSON. You
+can optionally choose the output filename and whether to parse the SP or DP
+table:
 
 ```sh
 npm run parse:scores <path/to/file.html> [output.json] [SP|DP]

--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ This project uses a Cloudflare Worker to serve the built React application and e
     `playtype` query parameter (`SP` or `DP`) to choose which table is parsed. The
     response is JSON in BATCH-MANUAL format.
 
-4.  The Settings page provides a single upload box that accepts either a JSON
-    score dump or a raw Ganymede HTML file. You can get this HTML by right
-    clicking and saving your scores page at
-    `https://ganymede-cg.net/ddr/scores/**/********`. When uploading HTML,
-    choose SP or DP so the correct table is parsed. Scores parsed as SP or DP are
-    stored separately and will only appear when that play style is selected. Any
-    unmatched songs are listed in a console-style block below the upload button
-    so you can easily check for issues.
+4.  The Settings page provides a single upload box—found under **Beta Features**—
+    that accepts either a JSON score dump or a raw Ganymede HTML file. You can
+    get this HTML by right clicking and saving your scores page at
+    `https://ganymede-cg.net/ddr/scores/**/********`. When uploading HTML, choose
+    SP or DP so the correct table is parsed. Scores parsed as SP or DP are stored
+    separately and only appear when that play style is selected. Any unmatched
+    songs are listed in a console-style block below the upload button so you can
+    easily check for issues.
 
 The Worker configuration in `wrangler.jsonc` sets `not_found_handling` to `single_page_application` so that React Router can handle client-side routes.
 

--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ This project uses a Cloudflare Worker to serve the built React application and e
     response is JSON in BATCH-MANUAL format.
 
 4.  The Settings page provides a single upload box that accepts either a JSON
-    score dump or a raw Ganymede HTML file. When uploading HTML, choose SP or DP
-    to match the table type. Scores parsed as SP or DP are stored separately and
-    will only appear when that play style is selected. A separate control lets
-    you adjust the fuzzy match percentage used when importing scores. Any
+    score dump or a raw Ganymede HTML file. You can get this HTML by right
+    clicking and saving your scores page at
+    `https://ganymede-cg.net/ddr/scores/**/********`. When uploading HTML,
+    choose SP or DP so the correct table is parsed. Scores parsed as SP or DP are
+    stored separately and will only appear when that play style is selected. Any
     unmatched songs are listed in a console-style block below the upload button
     so you can easily check for issues.
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ This project uses a Cloudflare Worker to serve the built React application and e
     `playtype` query parameter (`SP` or `DP`) to choose which table is parsed. The
     response is JSON in BATCH-MANUAL format.
 
-4.  The Settings page includes an upload form that sends a Ganymede HTML file to
-    this endpoint. Scores parsed as SP or DP are stored separately and will only
-    appear when that play style is selected.
+4.  The Settings page provides a single upload box that accepts either a JSON
+    score dump or a raw Ganymede HTML file. When uploading HTML, choose SP or DP
+    to match the table type. Scores parsed as SP or DP are stored separately and
+    will only appear when that play style is selected.
 
 The Worker configuration in `wrangler.jsonc` sets `not_found_handling` to `single_page_application` so that React Router can handle client-side routes.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ This project uses a Cloudflare Worker to serve the built React application and e
     `playtype` query parameter (`SP` or `DP`) to choose which table is parsed. The
     response is JSON in BATCH-MANUAL format.
 
+4.  The Settings page includes an upload form that sends a Ganymede HTML file to
+    this endpoint and automatically stores the parsed scores locally.
+
 The Worker configuration in `wrangler.jsonc` sets `not_found_handling` to `single_page_application` so that React Router can handle client-side routes.
 
 ### Parsing Scores Locally

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ This project uses a Cloudflare Worker to serve the built React application and e
     score dump or a raw Ganymede HTML file. When uploading HTML, choose SP or DP
     to match the table type. Scores parsed as SP or DP are stored separately and
     will only appear when that play style is selected. A separate control lets
-    you adjust the fuzzy match percentage used when importing scores.
+    you adjust the fuzzy match percentage used when importing scores. Any
+    unmatched songs are listed in a console-style block below the upload button
+    so you can easily check for issues.
 
 The Worker configuration in `wrangler.jsonc` sets `not_found_handling` to `single_page_application` so that React Router can handle client-side routes.
 

--- a/README.md
+++ b/README.md
@@ -86,4 +86,17 @@ This project uses a Cloudflare Worker to serve the built React application and e
 
 2.  The worker exposes an example endpoint at `/api/hello` returning a greeting in JSON.
 
+3.  You can also POST a Ganymede score HTML dump to `/api/parse-scores`. The body
+    may be raw HTML or `multipart/form-data` with a `file` field. Pass an optional
+    `playtype` query parameter (`SP` or `DP`) to choose which table is parsed. The
+    response is JSON in BATCH-MANUAL format.
+
 The Worker configuration in `wrangler.jsonc` sets `not_found_handling` to `single_page_application` so that React Router can handle client-side routes.
+
+### Parsing Scores Locally
+
+Run the following script to convert a Ganymede score HTML file into JSON:
+
+```sh
+npm run parse:scores <path/to/file.html> [output.json] [SP|DP]
+```

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ This project uses a Cloudflare Worker to serve the built React application and e
 4.  The Settings page provides a single upload box that accepts either a JSON
     score dump or a raw Ganymede HTML file. When uploading HTML, choose SP or DP
     to match the table type. Scores parsed as SP or DP are stored separately and
-    will only appear when that play style is selected.
+    will only appear when that play style is selected. A separate control lets
+    you adjust the fuzzy match percentage used when importing scores.
 
 The Worker configuration in `wrangler.jsonc` sets `not_found_handling` to `single_page_application` so that React Router can handle client-side routes.
 

--- a/_worker.js
+++ b/_worker.js
@@ -1,8 +1,36 @@
 import { Hono } from 'hono'
+import { parseGanymedeHtml } from './src/utils/parseGanymedeHtml.js'
 
 const app = new Hono()
 
 app.get('/api/hello', (c) => c.json({ message: 'Hello from Hono!' }))
+
+app.post('/api/parse-scores', async (c) => {
+  const play = (c.req.query('playtype') || 'SP').toUpperCase();
+  const playtype = play === 'DP' ? 'DP' : 'SP';
+
+  const contentType = c.req.header('content-type') || '';
+  let html = '';
+
+  if (contentType.includes('multipart/form-data')) {
+    const form = await c.req.formData();
+    const file = form.get('file');
+    if (file && typeof file.text === 'function') {
+      html = await file.text();
+    } else {
+      html = (form.get('html') || '').toString();
+    }
+  } else {
+    html = await c.req.text();
+  }
+
+  if (!html) {
+    return c.json({ error: 'No HTML provided' }, 400);
+  }
+
+  const data = parseGanymedeHtml(html, playtype);
+  return c.json(data);
+})
 
 app.use('*', async (c) => {
   return c.env.ASSETS.fetch(c.req.raw)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@google/generative-ai": "^0.24.1",
         "chart.js": "^4.5.0",
+        "cheerio": "^1.1.2",
         "clsx": "^2.1.1",
         "fraction.js": "^4.0.13",
         "hono": "^4.8.5",
@@ -2339,6 +2340,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2449,6 +2456,48 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/clsx": {
@@ -2577,6 +2626,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -2634,12 +2711,92 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.177",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.177.tgz",
       "integrity": "sha512-7EH2G59nLsEMj97fpDuvVcYi6lwTcM1xuWw3PssD8xzboAW7zj7iB3COEEEATUfjLHrs5uKBLQT03V/8URx06g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -3134,6 +3291,49 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3488,6 +3688,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3582,6 +3794,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -3935,6 +4196,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -4219,7 +4486,6 @@
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.12.0.tgz",
       "integrity": "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -4367,6 +4633,27 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "cf:dev": "wrangler dev",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "parse:scores": "node scripts/parse-ganymede-html.mjs"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
@@ -19,16 +20,17 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@google/generative-ai": "^0.24.1",
     "chart.js": "^4.5.0",
+    "cheerio": "^1.1.2",
     "clsx": "^2.1.1",
     "fraction.js": "^4.0.13",
+    "hono": "^4.8.5",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
     "react-select": "^5.10.1",
-    "react-window": "^1.8.11",
-    "hono": "^4.8.5"
+    "react-window": "^1.8.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/scripts/parse-ganymede-html.mjs
+++ b/scripts/parse-ganymede-html.mjs
@@ -1,0 +1,26 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { parseGanymedeHtml } from '../src/utils/parseGanymedeHtml.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const [input, output = 'ganymede-scores.json', play = 'SP'] = process.argv.slice(2);
+
+if (!input) {
+  console.error('Usage: node scripts/parse-ganymede-html.mjs <input.html> [output.json] [SP|DP]');
+  process.exit(1);
+}
+
+(async () => {
+  try {
+    const html = await fs.readFile(path.resolve(__dirname, '..', input), 'utf-8');
+    const data = parseGanymedeHtml(html, play.toUpperCase());
+    await fs.writeFile(path.resolve(__dirname, '..', output), JSON.stringify(data, null, 2));
+    console.log(`Successfully created '${output}' with ${data.scores.length} scores.`);
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exit(1);
+  }
+})();

--- a/src/BPMTool.css
+++ b/src/BPMTool.css
@@ -693,4 +693,13 @@
     }
 }
 
+.score-badge {
+    background-color: var(--card-hover-bg-color);
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    margin-top: 0.25rem;
+    text-align: right;
+}
+
 

--- a/src/DanPage.jsx
+++ b/src/DanPage.jsx
@@ -3,10 +3,12 @@ import SongCard from './components/SongCard.jsx';
 import { loadDanData } from './utils/course-loader.js';
 import { SettingsContext } from './contexts/SettingsContext.jsx';
 import { useFilters } from './contexts/FilterContext.jsx';
+import { useScores } from './contexts/ScoresContext.jsx';
 import './App.css';
 import './components/SongCard.css';
 
 const DanSection = ({ danCourse, playMode, setSelectedGame, resetFilters }) => {
+  const { scores } = useScores();
   const [isCollapsed, setIsCollapsed] = useState(() => {
     try {
       return JSON.parse(localStorage.getItem(`dan-header-collapsed-${danCourse.name}`)) || false;
@@ -29,9 +31,20 @@ const DanSection = ({ danCourse, playMode, setSelectedGame, resetFilters }) => {
       </h2>
       {!isCollapsed && (
         <div className="song-grid">
-          {danCourse.songs.map((song, index) => (
-            <SongCard key={`${danCourse.name}-${song.title}-${index}`} song={song} playMode={playMode} setSelectedGame={setSelectedGame} resetFilters={resetFilters} />
-          ))}
+          {danCourse.songs.map((song, index) => {
+            const chartKey = `${song.title.toLowerCase()}-${song.difficulty.toLowerCase()}`;
+            const score = scores[song.mode]?.[chartKey]?.score;
+            return (
+              <SongCard
+                key={`${danCourse.name}-${song.title}-${index}`}
+                song={song}
+                playMode={playMode}
+                setSelectedGame={setSelectedGame}
+                resetFilters={resetFilters}
+                score={score}
+              />
+            );
+          })}
         </div>
       )}
     </section>

--- a/src/ListsPage.jsx
+++ b/src/ListsPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import SongCard from './components/SongCard.jsx';
 import { useGroups } from './contexts/GroupsContext.jsx';
 import { useFilters } from './contexts/FilterContext.jsx';
+import { useScores } from './contexts/ScoresContext.jsx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash, faPalette, faPlus, faPen } from '@fortawesome/free-solid-svg-icons';
 import CreateListModal from './components/CreateListModal.jsx';
@@ -11,6 +12,7 @@ import './VegaPage.css';
 import './ListsPage.css';
 
 const GroupSection = ({ group, removeChart, deleteGroup, updateColor, updateName, resetFilters, onEditChart, highlightKey }) => {
+  const { scores } = useScores();
   const [isCollapsed, setIsCollapsed] = useState(() => {
     try {
       return JSON.parse(localStorage.getItem(`dan-header-collapsed-${group.name}`)) || false;
@@ -90,7 +92,9 @@ const GroupSection = ({ group, removeChart, deleteGroup, updateColor, updateName
       {!isCollapsed && (
         <div className="song-grid">
           {group.charts.map((chart, idx) => {
-            const key = `${group.name}-${chart.title}-${chart.mode}-${chart.difficulty}`;
+            const highlightId = `${group.name}-${chart.title}-${chart.mode}-${chart.difficulty}`;
+            const chartKey = `${chart.title.toLowerCase()}-${chart.difficulty.toLowerCase()}`;
+            const score = scores[chart.mode]?.[chartKey]?.score;
             return (
               <SongCard
                 key={idx}
@@ -98,7 +102,8 @@ const GroupSection = ({ group, removeChart, deleteGroup, updateColor, updateName
                 resetFilters={resetFilters}
                 onRemove={showActions ? () => removeChart(group.name, chart) : undefined}
                 onEdit={showActions ? () => onEditChart(group.name, chart) : undefined}
-                highlight={highlightKey === key}
+                highlight={highlightKey === highlightId}
+                score={score}
               />
             );
           })}

--- a/src/RankingsPage.jsx
+++ b/src/RankingsPage.jsx
@@ -111,8 +111,8 @@ const RankingsPage = () => {
             resetFilters,
           };
           const key = `${song.title.toLowerCase()}-${diff.difficulty.toLowerCase()}`;
-          if (scores[key]) {
-            chart.score = scores[key].score;
+          if (scores[playStyle]?.[key]) {
+            chart.score = scores[playStyle][key].score;
           }
           charts.push(chart);
         }

--- a/src/Settings.css
+++ b/src/Settings.css
@@ -153,3 +153,16 @@
     border-radius: 0.5rem;
     margin-top: 1rem;
 }
+
+.upload-console {
+    background-color: var(--card-bg-color);
+    border: 1px solid var(--border-color);
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    font-family: monospace;
+    white-space: pre-wrap;
+    font-size: 0.875rem;
+    max-height: 200px;
+    overflow-y: auto;
+    margin-top: 0.5rem;
+}

--- a/src/Settings.css
+++ b/src/Settings.css
@@ -166,3 +166,19 @@
     overflow-y: auto;
     margin-top: 0.5rem;
 }
+
+.upload-control > input[type="file"],
+.upload-control > select,
+.upload-control > button {
+    flex: 1 1 0;
+    width: auto;
+    min-height: 2.5rem;
+}
+
+@media (max-width: 1024px) {
+    .upload-control > input[type="file"],
+    .upload-control > select,
+    .upload-control > button {
+        width: 100%;
+    }
+}

--- a/src/Settings.jsx
+++ b/src/Settings.jsx
@@ -40,7 +40,12 @@ const Settings = () => {
             const text = await file.text();
             const data = JSON.parse(text);
             if (!Array.isArray(data.scores)) return;
-            const newScores = { ...scores };
+            const play = (data.meta && data.meta.playtype) ? data.meta.playtype.toUpperCase() : 'SP';
+            const keyName = play === 'DP' ? 'double' : 'single';
+            const newScores = {
+                ...scores,
+                [keyName]: { ...(scores[keyName] || {}) },
+            };
             for (const entry of data.scores) {
                 const target = entry.identifier;
                 let best = null;
@@ -51,7 +56,7 @@ const Settings = () => {
                 }
                 if (best && bestSim > 0.4) {
                     const key = `${best.title.toLowerCase()}-${entry.difficulty.toLowerCase()}`;
-                    newScores[key] = { score: entry.score, lamp: entry.lamp };
+                    newScores[keyName][key] = { score: entry.score, lamp: entry.lamp };
                 }
             }
             setScores(newScores);
@@ -64,7 +69,12 @@ const Settings = () => {
 
     const importParsedScores = (data) => {
         if (!Array.isArray(data.scores)) return;
-        const newScores = { ...scores };
+        const play = (data.meta && data.meta.playtype) ? data.meta.playtype.toUpperCase() : 'SP';
+        const keyName = play === 'DP' ? 'double' : 'single';
+        const newScores = {
+            ...scores,
+            [keyName]: { ...(scores[keyName] || {}) },
+        };
         for (const entry of data.scores) {
             const target = entry.identifier;
             let best = null;
@@ -75,7 +85,7 @@ const Settings = () => {
             }
             if (best && bestSim > 0.4) {
                 const key = `${best.title.toLowerCase()}-${entry.difficulty.toLowerCase()}`;
-                newScores[key] = { score: entry.score, lamp: entry.lamp };
+                newScores[keyName][key] = { score: entry.score, lamp: entry.lamp };
             }
         }
         setScores(newScores);
@@ -101,7 +111,7 @@ const Settings = () => {
 
     const clearScores = () => {
         if (window.confirm('Delete all stored scores?')) {
-            setScores({});
+            setScores({ single: {}, double: {} });
         }
     };
 
@@ -252,7 +262,7 @@ const Settings = () => {
                         <div className="setting-text">
                             <h3>Upload Score JSON</h3>
                             <p>
-                                Import your DDR scores to display them on the Ranking page. Your browser currently stores {Object.keys(scores).length} scores.
+                                Import your DDR scores to display them on the Ranking page. Your browser currently stores {Object.keys(scores.single).length + Object.keys(scores.double).length} scores.
                             </p>
                         </div>
                         <div className="setting-control">

--- a/src/Settings.jsx
+++ b/src/Settings.jsx
@@ -37,13 +37,6 @@ const Settings = () => {
     const [processing, setProcessing] = useState(false);
     const [uploadMessage, setUploadMessage] = useState('');
     const [unmatchedLines, setUnmatchedLines] = useState([]);
-    const [fuzzyPercent, setFuzzyPercent] = useState(() => {
-        const stored = localStorage.getItem('fuzzyPercent');
-        return stored ? Number(stored) : 30;
-    });
-    useEffect(() => {
-        localStorage.setItem('fuzzyPercent', fuzzyPercent);
-    }, [fuzzyPercent]);
 
     const importParsedScores = (data) => {
         if (!Array.isArray(data.scores)) return { total: 0, unmatched: 0, unmatchedEntries: [] };
@@ -57,7 +50,7 @@ const Settings = () => {
         };
         let unmatched = 0;
         const unmatchedEntries = [];
-        const looseThreshold = fuzzyPercent / 100;
+        const looseThreshold = 0.3;
         for (const entry of data.scores) {
             const target = entry.identifier;
             let best = null;
@@ -271,30 +264,12 @@ const Settings = () => {
                     <h2 className="settings-sub-header">Scores</h2>
                     <div className="setting-card">
                         <div className="setting-text">
-                            <h3>Fuzzy Match Threshold</h3>
-                            <p>
-                                Set how loose the importer should be when matching song titles. Remaining
-                                unmatched scores will try again with this percentage after a first strict pass.
-                            </p>
-                        </div>
-                        <div className="setting-control">
-                            <input
-                                type="number"
-                                min="0"
-                                max="100"
-                                step="5"
-                                value={fuzzyPercent}
-                                onChange={(e) => setFuzzyPercent(Number(e.target.value))}
-                                className="settings-input"
-                                style={{ width: '5rem' }}
-                            />%
-                        </div>
-                    </div>
-                    <div className="setting-card">
-                        <div className="setting-text">
                             <h3>Upload Scores</h3>
                             <p>
-                                Import your DDR scores in JSON or HTML format. Your browser currently stores {Object.keys(scores.single).length} SP and {Object.keys(scores.double).length} DP scores.
+                                Import your DDR scores in JSON or HTML format. Right click and save the
+                                HTML of your <code>ganymede-cg.net</code> scores page, then upload it here.
+                                Your browser currently stores {Object.keys(scores.single).length} SP and
+                                {Object.keys(scores.double).length} DP scores.
                             </p>
                         </div>
                         <div className="setting-control">

--- a/src/Settings.jsx
+++ b/src/Settings.jsx
@@ -261,7 +261,6 @@ const Settings = () => {
                         </div>
                     </div>
 
-                    <h2 className="settings-sub-header">Scores</h2>
                     <div className="setting-card">
                         <div className="setting-text">
                             <h3>Upload Scores</h3>
@@ -272,13 +271,13 @@ const Settings = () => {
                                 {Object.keys(scores.double).length} DP scores.
                             </p>
                         </div>
-                        <div className="setting-control">
+                        <div className="setting-control upload-control">
                             <input type="file" accept=".json,application/json,text/html" onChange={handleUploadFile} className="settings-input" />
-                            <select value={uploadPlaytype} onChange={(e) => setUploadPlaytype(e.target.value)} className="settings-select" style={{ marginLeft: '0.5rem' }}>
+                            <select value={uploadPlaytype} onChange={(e) => setUploadPlaytype(e.target.value)} className="settings-select">
                                 <option value="SP">SP</option>
                                 <option value="DP">DP</option>
                             </select>
-                            <button onClick={clearScores} className="settings-button" style={{ marginLeft: '0.5rem' }}>Delete Stats</button>
+                            <button onClick={clearScores} className="settings-button">Delete Stats</button>
                         </div>
                         {processing && (<div className="upload-status">Processing...</div>)}
                         {!processing && uploadMessage && (<div className="upload-status">{uploadMessage}</div>)}

--- a/src/VegaPage.jsx
+++ b/src/VegaPage.jsx
@@ -3,11 +3,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faVideo } from '@fortawesome/free-solid-svg-icons';
 import SongCard from './components/SongCard.jsx';
 import { useFilters } from './contexts/FilterContext.jsx';
+import { useScores } from './contexts/ScoresContext.jsx';
 import { loadVegaData } from './utils/course-loader.js';
 import './App.css';
 import './VegaPage.css';
 
 const DanSection = ({ danCourse, setSelectedGame, resetFilters }) => {
+    const { scores } = useScores();
     const [isCollapsed, setIsCollapsed] = useState(() => {
         try {
             return JSON.parse(localStorage.getItem(`dan-header-collapsed-${danCourse.name}`)) || false;
@@ -34,9 +36,19 @@ const DanSection = ({ danCourse, setSelectedGame, resetFilters }) => {
             </h2>
             {!isCollapsed && (
               <div className={songGridClasses}>
-                  {danCourse.songs.map((song, index) => (
-                      <SongCard key={`${danCourse.name}-${song.title}-${index}`} song={song} setSelectedGame={setSelectedGame} resetFilters={resetFilters} />
-                  ))}
+                  {danCourse.songs.map((song, index) => {
+                      const chartKey = `${song.title.toLowerCase()}-${song.difficulty.toLowerCase()}`;
+                      const score = scores[song.mode]?.[chartKey]?.score;
+                      return (
+                          <SongCard
+                              key={`${danCourse.name}-${song.title}-${index}`}
+                              song={song}
+                              setSelectedGame={setSelectedGame}
+                              resetFilters={resetFilters}
+                              score={score}
+                          />
+                      );
+                  })}
               </div>
             )}
         </section>

--- a/src/components/SongInfoBar.jsx
+++ b/src/components/SongInfoBar.jsx
@@ -3,6 +3,7 @@ import { DifficultyMeter } from './DifficultyMeter';
 import { difficultyLevels, difficultyNameMapping } from '../utils/difficulties.js';
 import { useFilters } from '../contexts/FilterContext.jsx';
 import { SettingsContext } from '../contexts/SettingsContext.jsx';
+import { useScores } from '../contexts/ScoresContext.jsx';
 import '../BPMTool.css';
 
 const SongInfoBar = ({
@@ -29,6 +30,13 @@ const SongInfoBar = ({
 
   const { filters } = useFilters();
   const { showRankedRatings } = useContext(SettingsContext);
+  const { scores } = useScores();
+
+  const currentScore = React.useMemo(() => {
+    if (!currentChart) return null;
+    const key = `${songTitle.toLowerCase()}-${currentChart.difficulty.toLowerCase()}`;
+    return scores[currentChart.mode]?.[key]?.score || null;
+  }, [scores, currentChart, songTitle]);
 
   const renderDifficulties = (style) => { // style is 'single' or 'double'
     if (!simfileData || !difficulties) return null;
@@ -108,10 +116,12 @@ const SongInfoBar = ({
       {!isCollapsed && (
         <div className="details-grid bpm-tool-grid">
           <div className={`grid-item difficulty-container ${playStyle === 'single' ? 'grid-item-sp' : 'grid-item-dp'}`}>
-              <span className="difficulty-label">Difficulty:</span>
               <div className={`difficulty-meters-container${showRankedRatings ? ' ranked' : ''}`}>
                 {renderDifficulties(playStyle)}
               </div>
+              {currentScore != null && (
+                <div className="score-badge">{currentScore.toLocaleString()}</div>
+              )}
           </div>
           <div className="bpm-core-container">
             <div className="grid-item grid-item-bpm">

--- a/src/contexts/ScoresContext.jsx
+++ b/src/contexts/ScoresContext.jsx
@@ -6,7 +6,15 @@ export const ScoresContext = createContext();
 export const ScoresProvider = ({ children }) => {
   const [scores, setScores] = useState(() => {
     const saved = localStorage.getItem('ddrScores');
-    return saved ? JSON.parse(saved) : {};
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      // Migrate old flat structure to new playstyle-separated format
+      if (!parsed.single && !parsed.double) {
+        return { single: parsed, double: {} };
+      }
+      return parsed;
+    }
+    return { single: {}, double: {} };
   });
 
   useEffect(() => {

--- a/src/utils/parseGanymedeHtml.js
+++ b/src/utils/parseGanymedeHtml.js
@@ -1,4 +1,4 @@
-import cheerio from 'cheerio';
+import { load } from 'cheerio';
 
 const lampMapping = {
   'MARVELOUS FC': 'MARVELOUS FULL COMBO',
@@ -25,7 +25,7 @@ const romanNumeralMap = {
 };
 
 export function parseGanymedeHtml(html, playtype = 'SP') {
-  const $ = cheerio.load(html);
+  const $ = load(html);
   const tbody = $(`tbody#${playtype.toLowerCase()}-tbody`);
   const scoresData = {
     meta: { game: 'ddr', playtype, service: 'Ganymede' },

--- a/src/utils/parseGanymedeHtml.js
+++ b/src/utils/parseGanymedeHtml.js
@@ -1,0 +1,89 @@
+import cheerio from 'cheerio';
+
+const lampMapping = {
+  'MARVELOUS FC': 'MARVELOUS FULL COMBO',
+  'PERFECT FC': 'PERFECT FULL COMBO',
+  'GREAT FC': 'GREAT FULL COMBO',
+  'GOOD FC': 'FULL COMBO',
+  'ASSIST CLEAR': 'ASSIST',
+  'LIFE CLEAR': 'CLEAR',
+  CLEAR: 'CLEAR',
+  FAILED: 'FAILED',
+};
+const lampKeysSorted = Object.keys(lampMapping).sort((a, b) => b.length - a.length);
+
+const romanNumeralMap = {
+  '\u2160': 'I',
+  '\u2161': 'II',
+  '\u2162': 'III',
+  '\u2163': 'IV',
+  '\u2164': 'V',
+  '\u2165': 'VI',
+  '\u2166': 'VII',
+  '\u2167': 'VIII',
+  '\u2168': 'IX',
+};
+
+export function parseGanymedeHtml(html, playtype = 'SP') {
+  const $ = cheerio.load(html);
+  const tbody = $(`tbody#${playtype.toLowerCase()}-tbody`);
+  const scoresData = {
+    meta: { game: 'ddr', playtype, service: 'Ganymede' },
+    scores: [],
+  };
+  if (tbody.length === 0) {
+    return scoresData;
+  }
+  const headers = $('thead')
+    .find('th')
+    .slice(1)
+    .map((_, el) => $(el).text().trim())
+    .get();
+  tbody.find('tr').each((_, row) => {
+    const cols = $(row).find('td');
+    const titleArtist = cols.first();
+    const title = titleArtist.find('strong').text().trim();
+    const artist = titleArtist
+      .contents()
+      .filter((_, n) => n.type === 'text')
+      .last()
+      .text()
+      .trim();
+    cols.slice(1).each((i, cell) => {
+      const cellText = $(cell).text().trim();
+      if (cellText === '-') return;
+      const scoreLink = $(cell).find('a');
+      if (!scoreLink.length) return;
+      const score = parseInt(scoreLink.text().replace(/,/g, ''), 10);
+      const cellLines = $(cell)
+        .text()
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      let rawLampText = 'NO PLAY';
+      if (cellLines.length > 2) rawLampText = cellLines[1];
+      let lamp = rawLampText;
+      let flare;
+      for (const key of lampKeysSorted) {
+        if (rawLampText.startsWith(key)) {
+          lamp = lampMapping[key];
+          const flareText = rawLampText.slice(key.length).trim();
+          if (flareText) flare = romanNumeralMap[flareText] || flareText;
+          break;
+        }
+      }
+      const difficulty = headers[i];
+      const entry = {
+        score,
+        lamp,
+        difficulty,
+        matchType: 'songTitle',
+        identifier: title,
+        artist,
+      };
+      if (flare) entry.optional = { flare };
+      scoresData.scores.push(entry);
+    });
+  });
+  return scoresData;
+}

--- a/src/utils/stringSimilarity.js
+++ b/src/utils/stringSimilarity.js
@@ -1,4 +1,9 @@
-export const normalizeString = (str) => str.toLowerCase().replace(/[^a-z0-9]/g, '');
+export const normalizeString = (str) =>
+    str
+        .toLowerCase()
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^\p{L}\p{N}]/gu, '');
 
 export const levenshtein = (a, b) => {
     const m = a.length;


### PR DESCRIPTION
## Summary
- implement `parseGanymedeHtml` utility with cheerio
- add CLI script to parse local HTML files
- expose `/api/parse-scores` endpoint from Cloudflare worker
- document new API endpoint and local parsing script

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e367ef654832695cde464cf1b9bf9