### PR TITLE
Align modal close buttons with headers

### DIFF
--- a/src/BPMTool.jsx
+++ b/src/BPMTool.jsx
@@ -216,37 +216,6 @@ const BPMTool = ({ smData, simfileData, currentChart, setCurrentChart, onSongSel
     const { scores } = useScores();
     const location = useLocation();
 
-    const isChartFilteredOut = (chart, currentFilters, currentPlayStyle, allScores, simfileWithRatings) => {
-        // Check level range filter
-        if ((currentFilters.difficultyMin && chart.feet < Number(currentFilters.difficultyMin)) ||
-            (currentFilters.difficultyMax && chart.feet > Number(currentFilters.difficultyMax))) {
-            return true;
-        }
-        // Check difficulty name filter
-        const lowerCaseFilterNames = (currentFilters.difficultyNames || []).map(n => n.toLowerCase());
-        if (lowerCaseFilterNames.length > 0) {
-            if (!lowerCaseFilterNames.includes(chart.difficulty.toLowerCase())) {
-                return true;
-            }
-        }
-        // Check played status filter
-        if (currentFilters.playedStatus !== 'all') {
-            // Ensure songMetaEntry.title and songMetaEntry.title.titleName exist
-            if (!simfileWithRatings || !simfileWithRatings.title) {
-                return true;
-            }
-            const chartKey = `${simfileWithRatings.title.toLowerCase()}-${chart.difficulty.toLowerCase()}`;
-            const hasPlayed = allScores[currentPlayStyle]?.[chartKey] != null;
-
-            if (filters.playedStatus === 'played' && !hasPlayed) {
-                return true;
-            }
-            if (filters.playedStatus === 'notPlayed' && hasPlayed) {
-                return true;
-            }
-        }
-        return false;
-    };
 
     const [songOptions, setSongOptions] = useState([]);
     const [inputValue, setInputValue] = useState('');

--- a/src/components/AddToListModal.jsx
+++ b/src/components/AddToListModal.jsx
@@ -30,10 +30,12 @@ const AddToListModal = ({ isOpen, onClose, groups, onAdd }) => {
   return (
     <div className={styles.modalBackdrop} onClick={onClose}>
       <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
-        <button className={styles.closeButton} onClick={onClose} aria-label="Close">
-          <FontAwesomeIcon icon={faTimes} />
-        </button>
-        <h3 className={styles.modalHeader}>Add Chart to List</h3>
+        <div className={styles.modalHeader}>
+          <h3>Add Chart to List</h3>
+          <button className={styles.closeButton} onClick={onClose} aria-label="Close">
+            <FontAwesomeIcon icon={faTimes} />
+          </button>
+        </div>
         <div className={styles.modalBody}>
           <div className={styles.formGroup}>
             <label>Select List</label>

--- a/src/components/AddToListModal.module.css
+++ b/src/components/AddToListModal.module.css
@@ -27,11 +27,17 @@
 }
 
 .modalHeader {
+    display: flex;
+    align-items: center;
+    padding: 0 1.5rem;
+}
+
+.modalHeader h3 {
     font-size: 1.5rem;
     font-weight: 700;
     color: var(--text-color);
     margin: 0;
-    padding: 0 1.5rem;
+    flex: 1;
 }
 
 .modalBody {
@@ -92,9 +98,6 @@
 }
 
 .closeButton {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
     background: transparent;
     border: none;
     color: var(--text-color);
@@ -121,11 +124,10 @@
 
     .modalHeader {
         padding-top: env(safe-area-inset-top, 1.5rem);
-        text-align: center;
     }
 
-    .closeButton {
-        top: calc(env(safe-area-inset-top, 0) + 0.5rem);
+    .modalHeader h3 {
+        text-align: center;
     }
 
     .modalBody {

--- a/src/components/AddToListModal.module.css
+++ b/src/components/AddToListModal.module.css
@@ -127,7 +127,7 @@
     }
 
     .modalHeader h3 {
-        text-align: center;
+        text-align: left;
     }
 
     .modalBody {

--- a/src/components/CreateListModal.jsx
+++ b/src/components/CreateListModal.jsx
@@ -31,10 +31,12 @@ const CreateListModal = ({ isOpen, onClose, onCreate }) => {
   return (
     <div className={styles.modalBackdrop} onClick={onClose}>
       <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
-        <button className={styles.closeButton} onClick={onClose} aria-label="Close">
-          <FontAwesomeIcon icon={faTimes} />
-        </button>
-        <h3 className={styles.modalHeader}>Create New List</h3>
+        <div className={styles.modalHeader}>
+          <h3>Create New List</h3>
+          <button className={styles.closeButton} onClick={onClose} aria-label="Close">
+            <FontAwesomeIcon icon={faTimes} />
+          </button>
+        </div>
         <div className={styles.modalBody}>
           <div className={styles.formGroup}>
             <label>List Name</label>

--- a/src/components/EditChartModal.jsx
+++ b/src/components/EditChartModal.jsx
@@ -45,10 +45,12 @@ const EditChartModal = ({ isOpen, onClose, chart, options, onSave }) => {
   return (
     <div className={styles.modalBackdrop} onClick={onClose}>
       <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
-        <button className={styles.closeButton} onClick={onClose} aria-label="Close">
-          <FontAwesomeIcon icon={faTimes} />
-        </button>
-        <h3 className={styles.modalHeader}>Edit Difficulty</h3>
+        <div className={styles.modalHeader}>
+          <h3>Edit Difficulty</h3>
+          <button className={styles.closeButton} onClick={onClose} aria-label="Close">
+            <FontAwesomeIcon icon={faTimes} />
+          </button>
+        </div>
         <div className={styles.modalBody}>
           <div className={styles.formGroup}>
             <label>Difficulty</label>

--- a/src/components/FilterModal.jsx
+++ b/src/components/FilterModal.jsx
@@ -87,10 +87,12 @@ const FilterModal = ({ isOpen, onClose, games, showLists, onCreateList }) => {
   return (
     <div className={styles.modalBackdrop} onClick={onClose}>
       <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
-        <button className={styles.closeButton} onClick={onClose} aria-label="Close">
-          <FontAwesomeIcon icon={faTimes} />
-        </button>
-        <h3 className={styles.modalHeader}>Song Filters</h3>
+        <div className={styles.modalHeader}>
+          <h3>Song Filters</h3>
+          <button className={styles.closeButton} onClick={onClose} aria-label="Close">
+            <FontAwesomeIcon icon={faTimes} />
+          </button>
+        </div>
         <div className={styles.modalBody}>
           <div className={styles.column}>
             <div className={styles.formGroup}>

--- a/src/components/FilterModal.module.css
+++ b/src/components/FilterModal.module.css
@@ -29,11 +29,17 @@
 }
 
 .modalHeader {
+    display: flex;
+    align-items: center;
+    padding: 0 1.5rem;
+}
+
+.modalHeader h3 {
     font-size: 1.5rem;
     font-weight: 700;
     color: var(--text-color);
     margin: 0;
-    padding: 0 1.5rem;
+    flex: 1;
 }
 
 .modalBody {
@@ -187,9 +193,6 @@
 }
 
 .closeButton {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
     background: transparent;
     border: none;
     color: var(--text-color);
@@ -243,11 +246,10 @@
 
     .modalHeader {
         padding-top: env(safe-area-inset-top, 1.5rem);
-        text-align:center;
     }
 
-    .closeButton {
-        top: calc(env(safe-area-inset-top, 0) + 0.5rem);
+    .modalHeader h3 {
+        text-align:center;
     }
 
     .modalBody {

--- a/src/components/FilterModal.module.css
+++ b/src/components/FilterModal.module.css
@@ -249,7 +249,7 @@
     }
 
     .modalHeader h3 {
-        text-align:center;
+        text-align:left;
     }
 
     .modalBody {

--- a/src/components/SortModal.jsx
+++ b/src/components/SortModal.jsx
@@ -43,10 +43,12 @@ const SortModal = ({ isOpen, onClose, sortKey, setSortKey, ascending, setAscendi
   return (
     <div className={styles.modalBackdrop} onClick={onClose}>
       <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
-        <button className={styles.closeButton} onClick={onClose} aria-label="Close">
-          <FontAwesomeIcon icon={faTimes} />
-        </button>
-        <h3 className={styles.modalHeader}>Sort Songs</h3>
+        <div className={styles.modalHeader}>
+          <h3>Sort Songs</h3>
+          <button className={styles.closeButton} onClick={onClose} aria-label="Close">
+            <FontAwesomeIcon icon={faTimes} />
+          </button>
+        </div>
         <div className={styles.modalBody}>
           <div className={styles.formGroup}>
             <label>Sort By</label>


### PR DESCRIPTION
## Summary
- remove unused helper in BPMTool
- refactor modal headers to include close buttons
- style modal headers for inline close button alignment

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68862753241083268bbac02cd7024497