### PR TITLE
feat: show Vega ranking results

### DIFF
--- a/public/vega-results.json
+++ b/public/vega-results.json
@@ -1,0 +1,37 @@
+{
+  "2025-07": {
+    "Light": {
+      "video": "https://www.youtube.com/watch?v=u5NOCla1GQw",
+      "results": [
+        {"position": 1, "name": "AL2K4", "score": 2933},
+        {"position": 2, "name": "PASCALX2", "score": 2847},
+        {"position": 3, "name": "SCADGE", "score": 2689},
+        {"position": 4, "name": "STANK", "score": 1941},
+        {"position": 5, "name": "NIBLET", "score": 1536}
+      ]
+    },
+    "Heavy": {
+      "video": "https://www.youtube.com/watch?v=SWUNH7MjaBA",
+      "results": [
+        {"position": 1, "name": "HAL", "score": 4588},
+        {"position": 2, "name": "CCD", "score": 4426},
+        {"position": 3, "name": "ALICE", "score": 4340},
+        {"position": 4, "name": "BADATDDR", "score": 4268},
+        {"position": 5, "name": "OEA", "score": 4037},
+        {"position": 6, "name": "OSKARTM", "score": 3811},
+        {"position": 7, "name": "SAM-JWBT", "score": 1328}
+      ]
+    },
+    "Extra": {
+      "video": "https://www.youtube.com/watch?v=DRhCeHFBe6M",
+      "results": [
+        {"position": 1, "name": "JYNXATU", "score": 2531},
+        {"position": 2, "name": "BADATDDR", "score": 2239},
+        {"position": 3, "name": "OEA", "score": 2120},
+        {"position": 4, "name": "ALICE", "score": 1852},
+        {"position": 5, "name": "STARKY", "score": 1690},
+        {"position": 6, "name": "SCADGE", "score": 1}
+      ]
+    }
+  }
+}

--- a/src/VegaPage.css
+++ b/src/VegaPage.css
@@ -38,6 +38,60 @@
     background-color: var(--accent-color-light);
 }
 
+.results-section {
+    margin: 2rem 0;
+}
+
+.results-header {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.results-container {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.results-category {
+    flex: 1;
+    min-width: 200px;
+    background-color: var(--card-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    padding: 1rem;
+}
+
+.results-category h3 {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 0;
+}
+
+.results-category ol {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.results-category li {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.25rem 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.results-category li:last-child {
+    border-bottom: none;
+}
+
+.results-video-link {
+    color: var(--accent-color);
+    margin-left: 0.5rem;
+    text-decoration: none;
+}
+
 
 .mobile-record-buttons {
     display: none;

--- a/src/VegaPage.css
+++ b/src/VegaPage.css
@@ -39,18 +39,21 @@
 }
 
 .results-section {
-    margin: 2rem 0;
+    margin-bottom: 1rem;
 }
 
 .results-header {
     text-align: center;
-    margin-bottom: 1rem;
 }
 
 .results-container {
     display: flex;
     gap: 1rem;
     flex-wrap: wrap;
+    padding: 0.75rem;
+    background-color: var(--bg-color-light);
+    border-bottom-left-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
 }
 
 .results-category {

--- a/src/VegaPage.css
+++ b/src/VegaPage.css
@@ -95,6 +95,11 @@
     text-decoration: none;
 }
 
+.song-bpm.score-gap {
+    display: inline;
+    margin-left: 0.25rem;
+}
+
 
 .mobile-record-buttons {
     display: none;

--- a/src/VegaPage.css
+++ b/src/VegaPage.css
@@ -97,7 +97,7 @@
 
 .song-bpm.score-gap {
     display: inline;
-    margin-left: 0.25rem;
+    margin-right: 0.25rem;
 }
 
 

--- a/src/VegaPage.jsx
+++ b/src/VegaPage.jsx
@@ -128,10 +128,10 @@ const ResultsSection = ({ results, selectedMonth }) => {
                                                 {entry.position}. {entry.name}
                                             </span>
                                             <span className="result-score">
-                                                {entry.score}
                                                 {diff > 0 && (
                                                     <span className="song-bpm score-gap">(-{diff})</span>
                                                 )}
+                                                {entry.score}
                                             </span>
                                         </li>
                                     );

--- a/src/VegaPage.jsx
+++ b/src/VegaPage.jsx
@@ -94,29 +94,50 @@ const ResultsSection = ({ results, selectedMonth }) => {
         timeZone: 'UTC',
     });
     return (
-        <section className="results-section">
-            <h2 className="results-header">Ranking Results – {monthLabel}</h2>
+        <section className="dan-section results-section">
+            <h2
+                className="dan-header results-header"
+                style={{ backgroundColor: 'var(--accent-color)' }}
+            >
+                Ranking Results – {monthLabel}
+            </h2>
             <div className="results-container">
-                {Object.entries(results).map(([category, data]) => (
-                    <div key={category} className="results-category">
-                        <h3>
-                            {category}
-                            {data.video && (
-                                <a href={data.video} target="_blank" rel="noopener noreferrer" className="results-video-link">
-                                    <FontAwesomeIcon icon={faVideo} />
-                                </a>
-                            )}
-                        </h3>
-                        <ol>
-                            {data.results.map((entry) => (
-                                <li key={entry.position}>
-                                    <span className="result-name">{entry.position}. {entry.name}</span>
-                                    <span className="result-score">{entry.score}</span>
-                                </li>
-                            ))}
-                        </ol>
-                    </div>
-                ))}
+                {Object.entries(results).map(([category, data]) => {
+                    const firstScore = data.results[0]?.score || 0;
+                    return (
+                        <div key={category} className="results-category">
+                            <h3>
+                                {category}
+                                {data.video && (
+                                    <a
+                                        href={data.video}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="results-video-link"
+                                    >
+                                        <FontAwesomeIcon icon={faVideo} />
+                                    </a>
+                                )}
+                            </h3>
+                            <ol>
+                                {data.results.map((entry) => {
+                                    const diff = firstScore - entry.score;
+                                    return (
+                                        <li key={entry.position}>
+                                            <span className="result-name">
+                                                {entry.position}. {entry.name}
+                                            </span>
+                                            <span className="result-score">
+                                                {entry.score}
+                                                {diff > 0 && ` (-${diff})`}
+                                            </span>
+                                        </li>
+                                    );
+                                })}
+                            </ol>
+                        </div>
+                    );
+                })}
             </div>
         </section>
     );

--- a/src/VegaPage.jsx
+++ b/src/VegaPage.jsx
@@ -129,7 +129,9 @@ const ResultsSection = ({ results, selectedMonth }) => {
                                             </span>
                                             <span className="result-score">
                                                 {entry.score}
-                                                {diff > 0 && ` (-${diff})`}
+                                                {diff > 0 && (
+                                                    <span className="song-bpm score-gap">(-{diff})</span>
+                                                )}
                                             </span>
                                         </li>
                                     );

--- a/src/utils/course-loader.js
+++ b/src/utils/course-loader.js
@@ -30,3 +30,19 @@ export const loadVegaData = async () => {
     }
 };
 
+// Fetches the pre-processed Vega ranking results.
+export const loadVegaResults = async () => {
+    try {
+        const response = await fetch('/vega-results.json');
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+        console.log("Loaded Vega ranking results.");
+        return data;
+    } catch (error) {
+        console.error("Error fetching Vega ranking results:", error);
+        return {};
+    }
+};
+


### PR DESCRIPTION
## Summary
- nest Vega ranking results under event months and include video links
- show results for the selected month on the Vega page using combined course/result months

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bb43dfc6083268d2490e2573e9976