### PR TITLE
feat: add auth pages and context

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -44,7 +44,8 @@ app.get('/user/data', authMiddleware, async (c) => {
     .bind(userId)
     .first()
   const data = row ? JSON.parse(row.data) : {}
-  return c.json(data)
+  const email = c.get('user').email
+  return c.json({ email, ...data })
 })
 
 app.put('/user/data', authMiddleware, async (c) => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,9 +16,13 @@ import RankingsPage from './RankingsPage.jsx';
 import './App.css';
 import './Tabs.css';
 import { storage } from './utils/remoteStorage.js';
+import LoginPage from './LoginPage.jsx';
+import SignupPage from './SignupPage.jsx';
+import { AuthProvider, useAuth } from './contexts/AuthContext.jsx';
 
 function AppRoutes() {
   const { theme, showLists, setPlayStyle, songlistOverride, playStyle } = useContext(SettingsContext);
+  const { user } = useAuth();
   const [smData, setSmData] = useState({ games: [], files: [] });
   const [simfileData, setSimfileData] = useState(null);
   const [currentChart, setCurrentChart] = useState(null);
@@ -163,6 +167,8 @@ function AppRoutes() {
           <Route path="/" element={<Navigate to="/bpm" replace />} />
             <Route path="/bpm" element={<BPMTool smData={smData} simfileData={simfileData} currentChart={currentChart} setCurrentChart={handleChartSelect} onSongSelect={handleSongSelect} selectedGame={selectedGame} setSelectedGame={setSelectedGame} view={view} setView={setView} />} />
             <Route path="/settings" element={<Settings />} />
+            <Route path="/login" element={user ? <Navigate to="/" replace /> : <LoginPage />} />
+            <Route path="/signup" element={user ? <Navigate to="/" replace /> : <SignupPage />} />
           </Routes>
         </div>
         <footer className="footer">
@@ -180,7 +186,9 @@ function AppWrapper() {
         <FilterProvider>
           <GroupsProvider>
             <Router>
-              <AppRoutes />
+              <AuthProvider>
+                <AppRoutes />
+              </AuthProvider>
             </Router>
           </GroupsProvider>
         </FilterProvider>

--- a/src/Auth.css
+++ b/src/Auth.css
@@ -1,0 +1,67 @@
+.auth-container {
+  min-height: calc(100vh - 4rem);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.auth-card {
+  background-color: var(--card-bg-color);
+  color: var(--text-color);
+  padding: 2rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+.auth-title {
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-input {
+  background-color: var(--card-bg-color);
+  color: var(--text-color);
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-color);
+}
+
+.auth-input:focus {
+  border-color: var(--accent-color);
+  outline: none;
+}
+
+.auth-button {
+  width: 100%;
+}
+
+.auth-button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.auth-error {
+  margin: 0.5rem 0 0;
+  color: var(--button-down-color);
+  text-align: center;
+}
+
+.auth-switch {
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.auth-switch a {
+  color: var(--accent-color);
+}
+

--- a/src/LoginPage.jsx
+++ b/src/LoginPage.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { useAuth } from './contexts/AuthContext.jsx';
+import './App.css';
+
+const LoginPage = () => {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await login(email, password);
+    } catch {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <h2>Login</h2>
+      <form onSubmit={handleSubmit} className="auth-form">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          required
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          required
+        />
+        <button type="submit" className="settings-button">Login</button>
+      </form>
+      {error && <p>{error}</p>}
+    </div>
+  );
+};
+
+export default LoginPage;
+

--- a/src/LoginPage.jsx
+++ b/src/LoginPage.jsx
@@ -1,44 +1,59 @@
 import React, { useState } from 'react';
 import { useAuth } from './contexts/AuthContext.jsx';
-import './App.css';
+import { Link } from 'react-router-dom';
+import './Auth.css';
 
 const LoginPage = () => {
   const { login } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
+    setLoading(true);
     try {
       await login(email, password);
-    } catch {
-      setError('Login failed');
+    } catch (err) {
+      setError(err.message);
+      setLoading(false);
     }
   };
 
   return (
-    <div className="auth-page">
-      <h2>Login</h2>
-      <form onSubmit={handleSubmit} className="auth-form">
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="Email"
-          required
-        />
-        <input
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder="Password"
-          required
-        />
-        <button type="submit" className="settings-button">Login</button>
-      </form>
-      {error && <p>{error}</p>}
+    <div className="auth-container">
+      <div className="auth-card">
+        <h2 className="auth-title">Login</h2>
+        <form onSubmit={handleSubmit} className="auth-form">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            className="auth-input"
+            autoComplete="email"
+            required
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            className="auth-input"
+            autoComplete="current-password"
+            required
+          />
+          <button type="submit" className="settings-button auth-button" disabled={loading}>
+            {loading ? 'Logging in...' : 'Log In'}
+          </button>
+          {error && <p className="auth-error">{error}</p>}
+        </form>
+        <div className="auth-switch">
+          <span>Need an account? <Link to="/signup">Sign up</Link></span>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/Settings.jsx
+++ b/src/Settings.jsx
@@ -9,6 +9,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUpload } from '@fortawesome/free-solid-svg-icons';
 import './Settings.css';
 import { useAuth } from './contexts/AuthContext.jsx';
+import { useNavigate } from 'react-router-dom';
 
 const Settings = () => {
     const {
@@ -28,6 +29,7 @@ const Settings = () => {
 
     const { scores, setScores } = useScores();
     const { user, logout } = useAuth();
+    const navigate = useNavigate();
 
     const [songMeta, setSongMeta] = useState([]);
     const [songLookup, setSongLookup] = useState({});
@@ -152,10 +154,16 @@ const Settings = () => {
         <div className="app-container">
             <div className="settings-content">
                 <div className="settings-inner-container">
-                    {user && (
+                    {user ? (
                         <div className="setting-card">
                             <div className="setting-control">
                                 <button onClick={logout} className="settings-button">Logout</button>
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="setting-card">
+                            <div className="setting-control">
+                                <button onClick={() => navigate('/login')} className="settings-button">Login</button>
                             </div>
                         </div>
                     )}

--- a/src/Settings.jsx
+++ b/src/Settings.jsx
@@ -8,6 +8,7 @@ import ThemeSwitcher from './components/ThemeSwitcher';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUpload } from '@fortawesome/free-solid-svg-icons';
 import './Settings.css';
+import { useAuth } from './contexts/AuthContext.jsx';
 
 const Settings = () => {
     const {
@@ -26,6 +27,7 @@ const Settings = () => {
     } = useContext(SettingsContext);
 
     const { scores, setScores } = useScores();
+    const { user, logout } = useAuth();
 
     const [songMeta, setSongMeta] = useState([]);
     const [songLookup, setSongLookup] = useState({});
@@ -150,6 +152,13 @@ const Settings = () => {
         <div className="app-container">
             <div className="settings-content">
                 <div className="settings-inner-container">
+                    {user && (
+                        <div className="setting-card">
+                            <div className="setting-control">
+                                <button onClick={logout} className="settings-button">Logout</button>
+                            </div>
+                        </div>
+                    )}
                     <div className="setting-card">
                         <div className="setting-text">
                             <h3>Target Scroll Speed</h3>

--- a/src/SignupPage.jsx
+++ b/src/SignupPage.jsx
@@ -1,44 +1,73 @@
 import React, { useState } from 'react';
 import { useAuth } from './contexts/AuthContext.jsx';
-import './App.css';
+import { Link } from 'react-router-dom';
+import './Auth.css';
 
 const SignupPage = () => {
   const { signup } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+    setLoading(true);
     try {
       await signup(email, password);
-    } catch {
-      setError('Signup failed');
+    } catch (err) {
+      setError(err.message);
+      setLoading(false);
     }
   };
 
   return (
-    <div className="auth-page">
-      <h2>Sign Up</h2>
-      <form onSubmit={handleSubmit} className="auth-form">
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="Email"
-          required
-        />
-        <input
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder="Password"
-          required
-        />
-        <button type="submit" className="settings-button">Sign Up</button>
-      </form>
-      {error && <p>{error}</p>}
+    <div className="auth-container">
+      <div className="auth-card">
+        <h2 className="auth-title">Sign Up</h2>
+        <form onSubmit={handleSubmit} className="auth-form">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            className="auth-input"
+            autoComplete="email"
+            required
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            className="auth-input"
+            autoComplete="new-password"
+            required
+          />
+          <input
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder="Confirm Password"
+            className="auth-input"
+            autoComplete="new-password"
+            required
+          />
+          <button type="submit" className="settings-button auth-button" disabled={loading}>
+            {loading ? 'Signing up...' : 'Sign Up'}
+          </button>
+          {error && <p className="auth-error">{error}</p>}
+        </form>
+        <div className="auth-switch">
+          <span>Already have an account? <Link to="/login">Log in</Link></span>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/SignupPage.jsx
+++ b/src/SignupPage.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { useAuth } from './contexts/AuthContext.jsx';
+import './App.css';
+
+const SignupPage = () => {
+  const { signup } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await signup(email, password);
+    } catch {
+      setError('Signup failed');
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <h2>Sign Up</h2>
+      <form onSubmit={handleSubmit} className="auth-form">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          required
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          required
+        />
+        <button type="submit" className="settings-button">Sign Up</button>
+      </form>
+      {error && <p>{error}</p>}
+    </div>
+  );
+};
+
+export default SignupPage;
+

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -26,12 +26,12 @@ export const AuthProvider = ({ children }) => {
   };
 
   const refreshToken = async () => {
-    const res = await fetch('/refresh', { method: 'POST' });
+    const res = await fetch('/refresh', { method: 'POST', credentials: 'include' });
     return res.ok;
   };
 
   const fetchUserData = async () => {
-    const res = await fetch('/user/data');
+    const res = await fetch('/user/data', { credentials: 'include' });
     if (res.ok) {
       const data = await res.json();
       setUser({ email: data.email || user?.email || '' });
@@ -58,7 +58,8 @@ export const AuthProvider = ({ children }) => {
     const res = await fetch('/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password })
+      body: JSON.stringify({ email, password }),
+      credentials: 'include'
     });
     if (!res.ok) {
       const data = await res.json().catch(() => ({}));
@@ -73,7 +74,8 @@ export const AuthProvider = ({ children }) => {
     const res = await fetch('/signup', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password })
+      body: JSON.stringify({ email, password }),
+      credentials: 'include'
     });
     if (!res.ok) {
       const data = await res.json().catch(() => ({}));
@@ -83,7 +85,7 @@ export const AuthProvider = ({ children }) => {
   };
 
   const logout = async () => {
-    await fetch('/logout', { method: 'POST' });
+    await fetch('/logout', { method: 'POST', credentials: 'include' });
     setUser(null);
     setScores({ single: {}, double: {} });
     storage.clear();

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -61,7 +61,8 @@ export const AuthProvider = ({ children }) => {
       body: JSON.stringify({ email, password })
     });
     if (!res.ok) {
-      throw new Error('Login failed');
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || 'Login failed');
     }
     setUser({ email });
     await fetchUserData();
@@ -75,7 +76,8 @@ export const AuthProvider = ({ children }) => {
       body: JSON.stringify({ email, password })
     });
     if (!res.ok) {
-      throw new Error('Signup failed');
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || 'Signup failed');
     }
     await login(email, password);
   };

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,99 @@
+/* eslint react-refresh/only-export-components: off */
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useScores } from './ScoresContext.jsx';
+import { SettingsContext } from './SettingsContext.jsx';
+import { storage } from '../utils/remoteStorage.js';
+
+export const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const navigate = useNavigate();
+  const { setScores } = useScores();
+  const settings = useContext(SettingsContext);
+
+  const applySettings = (data = {}) => {
+    if (!settings) return;
+    if (data.targetBPM !== undefined) settings.setTargetBPM(data.targetBPM);
+    if (data.apiKey !== undefined) settings.setApiKey(data.apiKey);
+    if (data.multiplierMode !== undefined) settings.setMultiplierMode(data.multiplierMode);
+    if (data.theme !== undefined) settings.setTheme(data.theme);
+    if (data.playStyle !== undefined) settings.setPlayStyle(data.playStyle);
+    if (data.showLists !== undefined) settings.setShowLists(data.showLists);
+    if (data.showRankedRatings !== undefined) settings.setShowRankedRatings(data.showRankedRatings);
+    if (data.songlistOverride !== undefined) settings.setSonglistOverride(data.songlistOverride);
+  };
+
+  const refreshToken = async () => {
+    const res = await fetch('/refresh', { method: 'POST' });
+    return res.ok;
+  };
+
+  const fetchUserData = async () => {
+    const res = await fetch('/user/data');
+    if (res.ok) {
+      const data = await res.json();
+      setUser({ email: data.email || user?.email || '' });
+      if (data.scores) setScores(data.scores);
+      if (data.settings) applySettings(data.settings);
+      return true;
+    }
+    if (res.status === 401) {
+      const refreshed = await refreshToken();
+      if (refreshed) {
+        return fetchUserData();
+      }
+      setUser(null);
+      navigate('/login');
+    }
+    return false;
+  };
+
+  useEffect(() => {
+    fetchUserData();
+  }, []);
+
+  const login = async (email, password) => {
+    const res = await fetch('/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    if (!res.ok) {
+      throw new Error('Login failed');
+    }
+    setUser({ email });
+    await fetchUserData();
+    navigate('/');
+  };
+
+  const signup = async (email, password) => {
+    const res = await fetch('/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    if (!res.ok) {
+      throw new Error('Signup failed');
+    }
+    await login(email, password);
+  };
+
+  const logout = async () => {
+    await fetch('/logout', { method: 'POST' });
+    setUser(null);
+    setScores({ single: {}, double: {} });
+    storage.clear();
+    navigate('/login');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, signup, logout, refreshUser: fetchUserData }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);
+

--- a/src/utils/remoteStorage.js
+++ b/src/utils/remoteStorage.js
@@ -48,4 +48,16 @@ function setItem(key, value) {
   });
 }
 
-export const storage = { init, getItem, setItem };
+function clear() {
+  for (const key of Object.keys(cache)) {
+    delete cache[key];
+  }
+  fetch('/user/data', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({}),
+  });
+}
+
+export const storage = { init, getItem, setItem, clear };


### PR DESCRIPTION
## Summary
- add login and signup pages that call Worker auth endpoints
- introduce AuthContext to manage user state, token refresh and logout
- persist user settings/scores and add logout button in settings

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d06c008d083269693349044ccd24d