### PR TITLE
fix: ensure secure flag for __Host cookies on logout

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -305,7 +305,7 @@ authApp.post('/logout', (c) => {
   for (const name of ['token', '__Host-token']) {
     setCookie(c, name, '', {
       httpOnly: true,
-      secure,
+      secure: name.startsWith('__Host-') ? true : secure,
       sameSite: 'Strict',
       path: '/',
       maxAge: 0,
@@ -360,7 +360,13 @@ authApp.post('/logout-all', authMiddleware, async (c) => {
   const isProd = (c.env?.ENV || '').toLowerCase() === 'production'
   const secure = isProd || c.req.url.startsWith('https://')
   for (const name of ['token', '__Host-token']) {
-    setCookie(c, name, '', { httpOnly: true, secure, sameSite: 'Strict', path: '/', maxAge: 0 })
+    setCookie(c, name, '', {
+      httpOnly: true,
+      secure: name.startsWith('__Host-') ? true : secure,
+      sameSite: 'Strict',
+      path: '/',
+      maxAge: 0,
+    })
   }
   return c.json({ success: true })
 })


### PR DESCRIPTION
## Summary
- fix auth logout to always set Secure on `__Host-token` cookies

## Testing
- `npm run lint` *(fails: '_e' is defined but never used; Empty block statement...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b41bad445083269c46e1d116dcca26