### PR TITLE
feat: add chart note type metrics

### DIFF
--- a/src/components/SongInfoBar.jsx
+++ b/src/components/SongInfoBar.jsx
@@ -173,20 +173,14 @@ const SongInfoBar = ({
                     <span className="song-speed">Steps:</span>
                     <span className="song-modifier">{metrics.steps?.toLocaleString?.() ?? 'N/A'}</span>
 
-                    <span className="song-speed">Stream:</span>
-                    <span className="song-modifier">{metrics.radar?.stream ?? 'N/A'}</span>
+                    <span className="song-speed">Holds:</span>
+                    <span className="song-modifier">{metrics.holds?.toLocaleString?.() ?? 'N/A'}</span>
 
-                    <span className="song-speed">Voltage:</span>
-                    <span className="song-modifier">{metrics.radar?.voltage ?? 'N/A'}</span>
+                    <span className="song-speed">Jumps:</span>
+                    <span className="song-modifier">{metrics.jumps?.toLocaleString?.() ?? 'N/A'}</span>
 
-                    <span className="song-speed">Air:</span>
-                    <span className="song-modifier">{metrics.radar?.air ?? 'N/A'}</span>
-
-                    <span className="song-speed">Freeze:</span>
-                    <span className="song-modifier">{metrics.radar?.freeze ?? 'N/A'}</span>
-
-                    <span className="song-speed">Chaos:</span>
-                    <span className="song-modifier">{metrics.radar?.chaos ?? 'N/A'}</span>
+                    <span className="song-speed">Shocks:</span>
+                    <span className="song-modifier">{metrics.shocks?.toLocaleString?.() ?? 'N/A'}</span>
                   </div>
                 </div>
               )}

--- a/src/utils/chartMetrics.js
+++ b/src/utils/chartMetrics.js
@@ -112,11 +112,13 @@ export function computeChartMetrics(chart) {
   const holds = Array.isArray(chart.freezes) ? chart.freezes.length : 0;
   // Jumps: exactly two notes in a single row
   let jumps = 0;
-  // Shocks: four or more notes in a single row (DDR "shock arrow")
+  // Shocks: rows consisting solely of 'M' (DDR shock arrow)
   let shocks = 0;
   for (const a of arrows) {
-    const taps = countTapsInRow(a.direction || '');
-    if (taps >= 4) {
+    const dir = a.direction || '';
+    const taps = countTapsInRow(dir);
+    const isShockRow = dir.length > 0 && [...dir].every((c) => c === 'M');
+    if (isShockRow) {
       shocks += 1;
     } else if (taps >= 2) {
       jumps += 1;

--- a/src/utils/chartMetrics.js
+++ b/src/utils/chartMetrics.js
@@ -106,12 +106,27 @@ function computeLastBeat(chart) {
 
 export function computeChartMetrics(chart) {
   if (!chart) return null;
-  const steps = (chart.arrows || []).reduce((acc, a) => acc + countTapsInRow(a.direction || ''), 0);
+  const arrows = chart.arrows || [];
+  const steps = arrows.reduce((acc, a) => acc + countTapsInRow(a.direction || ''), 0);
+  // Holds represent freeze/roll notes
+  const holds = Array.isArray(chart.freezes) ? chart.freezes.length : 0;
+  // Jumps: exactly two notes in a single row
+  let jumps = 0;
+  // Shocks: four or more notes in a single row (DDR "shock arrow")
+  let shocks = 0;
+  for (const a of arrows) {
+    const taps = countTapsInRow(a.direction || '');
+    if (taps >= 4) {
+      shocks += 1;
+    } else if (taps >= 2) {
+      jumps += 1;
+    }
+  }
   const firstOffset = chart.arrows && chart.arrows.length > 0 ? chart.arrows[0].offset : 0;
   const firstNoteSeconds = timeAtOffset(chart.bpm || [], chart.stops || [], firstOffset);
   const lastBeat = computeLastBeat(chart);
   const radar = approximateRadar(chart.arrows || [], chart.freezes || [], chart.bpm || [], chart.stops || [], lastBeat);
-  return { steps, firstNoteSeconds, radar, lastBeat };
+  return { steps, holds, jumps, shocks, firstNoteSeconds, radar, lastBeat };
 }
 
 export { timeAtOffset, songLengthSeconds };


### PR DESCRIPTION
## Summary
- compute holds, jumps, and shocks when parsing charts
- surface new note-type counts in chart metrics even when radar values are precomputed
- show holds/jumps/shocks alongside steps on BPM page
- hide inaccurate groove radar stats

## Testing
- `npm run lint` *(fails: no-unused-vars, empty block statements, react-hooks/exhaustive-deps warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b44051e06c8326baf729ca48b85e44